### PR TITLE
feat: undertone analysis — warm/cool/neutral badges + collection insights

### DIFF
--- a/apps/web/src/app/polishes/page.tsx
+++ b/apps/web/src/app/polishes/page.tsx
@@ -19,6 +19,8 @@ import {
 import { ColorDot } from "@/components/color-dot";
 import { QuantityControls } from "@/components/quantity-controls";
 import { Pagination } from "@/components/pagination";
+import { UndertoneBadge } from "@/components/undertone-badge";
+import { undertone } from "@/lib/color-utils";
 
 const PAGE_SIZE = 10;
 
@@ -207,6 +209,7 @@ export default function PolishesPage() {
           className="max-w-xs"
         />
 
+
         <label className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
           <input
             type="checkbox"
@@ -279,6 +282,7 @@ export default function PolishesPage() {
               <TableHead>Brand</TableHead>
               <TableHead>Name</TableHead>
               <TableHead className="w-12">Color</TableHead>
+              <TableHead>Tone</TableHead>
               <TableHead className="w-12">Find</TableHead>
               <TableHead>Finish</TableHead>
               <TableHead>Collection</TableHead>
@@ -288,7 +292,7 @@ export default function PolishesPage() {
           <TableBody>
             {pageItems.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
+                <TableCell colSpan={9} className="text-center text-muted-foreground py-8">
                   No polishes match your filters.
                 </TableCell>
               </TableRow>
@@ -318,6 +322,11 @@ export default function PolishesPage() {
                       >
                         <ColorDot hex={polish.colorHex} size="sm" />
                       </button>
+                    </TableCell>
+                    <TableCell>
+                      {polish.colorHex && (
+                        <UndertoneBadge undertone={undertone(polish.colorHex)} />
+                      )}
                     </TableCell>
                     <TableCell>
                       {polish.colorHex && (

--- a/apps/web/src/components/undertone-badge.tsx
+++ b/apps/web/src/components/undertone-badge.tsx
@@ -1,0 +1,31 @@
+import type { Undertone } from "@/lib/color-utils";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+const undertoneStyles: Record<Undertone, string> = {
+  warm: "bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-700",
+  cool: "bg-sky-100 text-sky-800 border-sky-300 dark:bg-sky-900/40 dark:text-sky-200 dark:border-sky-700",
+  neutral: "bg-stone-100 text-stone-700 border-stone-300 dark:bg-stone-800/40 dark:text-stone-300 dark:border-stone-600",
+};
+
+const undertoneLabels: Record<Undertone, string> = {
+  warm: "Warm",
+  cool: "Cool",
+  neutral: "Neutral",
+};
+
+interface UndertoneBadgeProps {
+  undertone: Undertone;
+  className?: string;
+}
+
+export function UndertoneBadge({ undertone, className }: UndertoneBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(undertoneStyles[undertone], "text-xs", className)}
+    >
+      {undertoneLabels[undertone]}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/undertone-breakdown.tsx
+++ b/apps/web/src/components/undertone-breakdown.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { Undertone } from "@/lib/color-utils";
+
+interface UndertoneBreakdownProps {
+  warm: number;
+  cool: number;
+  neutral: number;
+  total: number;
+}
+
+const barColors: Record<Undertone, string> = {
+  warm: "bg-amber-400 dark:bg-amber-500",
+  cool: "bg-sky-400 dark:bg-sky-500",
+  neutral: "bg-stone-400 dark:bg-stone-500",
+};
+
+const dotColors: Record<Undertone, string> = {
+  warm: "bg-amber-400",
+  cool: "bg-sky-400",
+  neutral: "bg-stone-400",
+};
+
+export function UndertoneBreakdown({ warm, cool, neutral, total }: UndertoneBreakdownProps) {
+  if (total === 0) return null;
+
+  const pct = (n: number) => Math.round((n / total) * 100);
+
+  const segments = ([
+    { tone: "warm" as const, count: warm },
+    { tone: "cool" as const, count: cool },
+    { tone: "neutral" as const, count: neutral },
+  ] satisfies { tone: Undertone; count: number }[]).filter((s) => s.count > 0);
+
+  return (
+    <div className="space-y-3">
+      {/* Stacked bar */}
+      <div className="flex h-4 rounded-full overflow-hidden bg-muted">
+        {segments.map(({ tone, count }) => (
+          <div
+            key={tone}
+            className={`${barColors[tone]} transition-all`}
+            style={{ width: `${pct(count)}%` }}
+            title={`${tone}: ${count} (${pct(count)}%)`}
+          />
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-between text-sm">
+        {(["warm", "cool", "neutral"] as const).map((tone) => {
+          const count = tone === "warm" ? warm : tone === "cool" ? cool : neutral;
+          return (
+            <div key={tone} className="flex items-center gap-1.5">
+              <span className={`inline-block h-2.5 w-2.5 rounded-full ${dotColors[tone]}`} />
+              <span className="capitalize">{tone}</span>
+              <span className="text-muted-foreground">{pct(count)}%</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add OKLAB-based undertone classification (`warm` / `cool` / `neutral`) using the `a` and `b` axes with chroma gating for greys
- New `undertone()`, `warmthScore()`, and `undertoneBreakdown()` utilities in `color-utils.ts`
- `<UndertoneBadge>` component with color-coded warm/cool/neutral pills
- `<UndertoneBreakdown>` component with horizontal stacked bar visualization
- Collection table now shows a Tone column with per-polish undertone badges
- Dashboard "Collection Breakdown" card shows aggregate undertone analysis with dominant tone callout

Closes #8

## Test plan
- [ ] Dashboard shows undertone breakdown bar and dominant tone label
- [ ] Collection table `/polishes` has a Tone column with warm/cool/neutral badges
- [ ] Verify pure greys/whites/blacks classify as neutral
- [ ] Verify warm reds/oranges classify as warm, blues/greens classify as cool

🤖 Generated with [Claude Code](https://claude.com/claude-code)