### PR TITLE
fix: invert color match percentage so identical colors show 100%

### DIFF
--- a/apps/web/src/components/color-search-results.tsx
+++ b/apps/web/src/components/color-search-results.tsx
@@ -66,7 +66,7 @@ export function ColorSearchResults({
                 </Badge>
               )}
               <span className="shrink-0 text-xs tabular-nums text-muted-foreground w-12 text-right">
-                {(polish.distance * 100).toFixed(0)}%
+                {((1 - polish.distance) * 100).toFixed(0)}%
               </span>
             </Link>
 


### PR DESCRIPTION
## Summary
- Color search results showed inverted match percentages — identical colors displayed 0% and completely different colors showed 100%
- Root cause: OKLAB `colorDistance()` returns 0 for identical colors and 1 for max difference, but the value was rendered directly as a percentage without inverting
- Fix: `(1 - polish.distance) * 100` in `color-search-results.tsx`

Closes #3

## Test plan
- [ ] Open `/polishes/search`, pick a color that exactly matches a polish in the collection — should show ~100%
- [ ] Pick a very different color — should show a low percentage
- [ ] Verify complementary mode percentages also make sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)