### PR TITLE
feat: add AI provider fallback chain to commit message generator

### DIFF
--- a/.husky/README.md
+++ b/.husky/README.md
@@ -10,11 +10,28 @@ This directory contains git hooks for SwatchWatch that enforce code quality and 
 
 ## AI-Powered Commit Messages
 
-The `prepare-commit-msg` hook can use Claude (if configured) to generate vibey commit message suggestions based on your staged changes.
+The `prepare-commit-msg` hook uses a provider fallback chain to generate commit suggestions from your staged diff.
+
+### Provider Cascade
+
+The hook tries each provider in order and uses the first one that works:
+
+| Priority | Provider | Requirements |
+|----------|----------|-------------|
+| 1 | **Claude CLI** | `claude` binary in PATH (uses Claude Code's own auth — no API key needed) |
+| 2 | **Anthropic API** | `ANTHROPIC_API_KEY` env var + `curl` + `jq` |
+| 3 | **OpenAI API** | `OPENAI_API_KEY` env var + `curl` + `jq` |
+| 4 | **Manual** | No requirements — prompts you to write your own message |
+
+If a provider fails (empty output or error), the hook automatically tries the next one.
 
 ### Setup
 
-To enable AI-generated suggestions, set your Anthropic API key:
+**Option 1: Claude Code CLI (recommended)**
+
+Install Claude Code from https://docs.anthropic.com/en/docs/claude-code — no API key needed, it uses its own auth.
+
+**Option 2: Anthropic API key**
 
 ```bash
 # Add to your ~/.zshrc or ~/.bashrc
@@ -23,33 +40,40 @@ export ANTHROPIC_API_KEY="your-api-key-here"
 
 Get your API key from: https://console.anthropic.com/settings/keys
 
+**Option 3: OpenAI API key**
+
+```bash
+# Add to your ~/.zshrc or ~/.bashrc
+export OPENAI_API_KEY="your-api-key-here"
+```
+
 ### How It Works
 
 1. When you run `git commit`, the hook analyzes your staged changes
-2. It sends the diff to Claude with a prompt for nail-polish-themed suggestions
-3. Claude generates 3 creative commit message options
+2. It detects the best available AI provider
+3. The provider generates 3 creative commit message options
 4. The suggestions appear as comments in your commit message editor
 5. Pick one, customize it, or write your own!
 
-### Fallback
+### No AI Available
 
-If no API key is set, the hook provides smart fallback suggestions based on file patterns:
-- `package.json` changes → dependency update messages
-- `.tsx/.ts` changes → component/feature messages  
-- Test file changes → testing messages
-- Documentation changes → docs messages
-- Style file changes → UI/styling messages
+If no AI provider is available, the hook writes a comment block telling you to write your own message — no auto-generated stub suggestions.
 
 ### Example Output
 
 ```
-# AI-generated nail polish commit suggestions:
+# AI-generated commit vibes (claude-cli):
 #
-# - chore: buff up test runner with glossy new polish
-# - fix: repair chipped husky hook configuration
-# - refactor: apply smooth top coat to commit workflow
+# - feat: ✨ add shimmer finish to swatch cards
+# - fix: polish swatch rendering edge cases
+# - docs: add glossy API notes 💅
 #
 # Pick one, customize it, or write your own.
+#
+# Format: <type>: <subject>
+# Types: feat, fix, refactor, docs, chore, test, style, perf
+#
+# Write your commit message above (delete all # comment lines)
 ```
 
 ### Emoji guideline
@@ -64,8 +88,8 @@ Don't put an emoji before the type.
 ## Vibe Words
 When writing commit messages, sprinkle in nail-polish-adjacent words:
 
-**Finishes/colors**: shimmer, chrome, glossy, matte, holographic  
-**Manicure verbs**: buff, file, coat, cure, polish, swatch  
+**Finishes/colors**: shimmer, chrome, glossy, matte, holographic
+**Manicure verbs**: buff, file, coat, cure, polish, swatch
 **Collection vibes**: stash, catalog, inventory, dupe
 
 ## Conventional Commits
@@ -84,9 +108,12 @@ All commits must follow the format: `<type>: <subject>`
 ## Troubleshooting
 
 **AI suggestions not appearing?**
-- Check that `ANTHROPIC_API_KEY` is exported (without printing it): `printenv ANTHROPIC_API_KEY >/dev/null && echo set || echo not-set`
+- Check which provider is detected: `sh -x .husky/generate-commit-msg.sh /tmp/test-msg`
+- For Claude CLI: verify `claude` is in your PATH: `which claude`
+- For Anthropic API: check key is set (without printing it): `printenv ANTHROPIC_API_KEY >/dev/null && echo set || echo not-set`
+- For OpenAI API: check key is set: `printenv OPENAI_API_KEY >/dev/null && echo set || echo not-set`
+- Both API providers require `jq`: `which jq`
 - Verify the script is executable: `ls -l .husky/generate-commit-msg.sh`
-- Check for errors: `sh -x .husky/generate-commit-msg.sh .git/COMMIT_EDITMSG`
 
 **Pre-commit hook failing?**
 - Ensure workspace packages have test scripts or they use `--if-present` flag

--- a/.husky/generate-commit-msg.sh
+++ b/.husky/generate-commit-msg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-# Vibey commit message generator
-# Uses Anthropic Claude to generate commit suggestions based on staged changes
+# AI commit message generator with provider fallback
+# Tries: Claude CLI → Anthropic API → OpenAI API → manual
 
 COMMIT_MSG_FILE=$1
 DIFF_OUTPUT=$(git diff --cached --stat)
@@ -14,7 +14,7 @@ fi
 # Get detailed diff for AI context
 FULL_DIFF=$(git diff --cached)
 
-# Prepare prompt for AI
+# Shared prompt for all AI providers
 PROMPT="You're writing commit message suggestions for SwatchWatch.
 
 Generate 3 vibey Conventional Commit suggestions inspired by the staged changes.
@@ -37,26 +37,114 @@ $(echo "$FULL_DIFF" | head -n 500)
 
 Generate exactly 3 suggestions, one per line, no explanations or numbering."
 
-# Try to use Claude API if available
-if command -v claude 2>/dev/null && [ -n "$ANTHROPIC_API_KEY" ]; then
-  SUGGESTIONS=$(echo "$PROMPT" | claude --model claude-3-5-sonnet-20241022 --max-tokens 200 2>/dev/null)
-elif [ -n "$ANTHROPIC_API_KEY" ] && command -v jq 2>/dev/null; then
-  # Use curl if claude CLI not available (requires jq)
-  SUGGESTIONS=$(curl -s https://api.anthropic.com/v1/messages \
+# --- Provider detection ---
+
+detect_provider() {
+  if command -v claude >/dev/null 2>&1; then
+    echo "claude-cli"
+  elif [ -n "$ANTHROPIC_API_KEY" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    echo "anthropic-api"
+  elif [ -n "$OPENAI_API_KEY" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    echo "openai-api"
+  else
+    echo "manual"
+  fi
+}
+
+# --- Provider implementations ---
+
+try_claude_cli() {
+  claude -p --model haiku --max-turns 1 "$PROMPT" 2>/dev/null
+}
+
+try_anthropic_api() {
+  curl -s https://api.anthropic.com/v1/messages \
     -H "x-api-key: $ANTHROPIC_API_KEY" \
     -H "anthropic-version: 2023-06-01" \
     -H "content-type: application/json" \
-    -d "{\"model\":\"claude-3-5-sonnet-20241022\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":$(echo "$PROMPT" | jq -Rs .)}]}" \
-    | jq -r '.content[0].text' 2>/dev/null)
-fi
+    -d "{\"model\":\"claude-3-5-haiku-20241022\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":$(printf '%s' "$PROMPT" | jq -Rs .)}]}" \
+    | jq -r '.content[0].text' 2>/dev/null
+}
 
-# Write suggestions to commit message file
-cat > "$COMMIT_MSG_FILE" << EOF
-# AI-generated commit vibes:
+try_openai_api() {
+  curl -s https://api.openai.com/v1/chat/completions \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -H "content-type: application/json" \
+    -d "{\"model\":\"gpt-4o-mini\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":$(printf '%s' "$PROMPT" | jq -Rs .)}]}" \
+    | jq -r '.choices[0].message.content' 2>/dev/null
+}
+
+write_manual_msg() {
+  cat > "$COMMIT_MSG_FILE" << 'EOF'
+# No AI provider available — write your commit message above.
+#
+# To enable AI suggestions, set up one of:
+#   1. Claude Code CLI: install from https://docs.anthropic.com/en/docs/claude-code
+#   2. Anthropic API key: export ANTHROPIC_API_KEY="sk-..."
+#   3. OpenAI API key: export OPENAI_API_KEY="sk-..."
+#
+# Format: <type>: <subject>
+# Types: feat, fix, refactor, docs, chore, test, style, perf
+#
+# Write your commit message above (delete all # comment lines)
+EOF
+}
+
+# --- Main flow ---
+
+# try_provider runs a provider function and sets SUGGESTIONS on success.
+# Returns 0 if the provider produced usable output, 1 otherwise.
+try_provider() {
+  SUGGESTIONS=$("$@")
+  if [ $? -ne 0 ] || [ -z "$SUGGESTIONS" ]; then
+    SUGGESTIONS=""
+    return 1
+  fi
+  # Filter out "null" responses from jq (API errors)
+  case "$SUGGESTIONS" in
+    null|"null") SUGGESTIONS=""; return 1 ;;
+  esac
+  return 0
+}
+
+PROVIDER=$(detect_provider)
+SUGGESTIONS=""
+
+# Try detected provider, then fall through to next on failure
+case "$PROVIDER" in
+  claude-cli)
+    try_provider try_claude_cli || {
+      PROVIDER="anthropic-api"
+      if [ -n "$ANTHROPIC_API_KEY" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        try_provider try_anthropic_api
+      fi
+    }
+    if [ -z "$SUGGESTIONS" ]; then
+      PROVIDER="openai-api"
+      if [ -n "$OPENAI_API_KEY" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        try_provider try_openai_api
+      fi
+    fi
+    ;;
+  anthropic-api)
+    try_provider try_anthropic_api || {
+      PROVIDER="openai-api"
+      if [ -n "$OPENAI_API_KEY" ] && command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        try_provider try_openai_api
+      fi
+    }
+    ;;
+  openai-api)
+    try_provider try_openai_api
+    ;;
+esac
+
+if [ -n "$SUGGESTIONS" ]; then
+  cat > "$COMMIT_MSG_FILE" << EOF
+# AI-generated commit vibes ($PROVIDER):
 #
 EOF
 
-if [ -n "$SUGGESTIONS" ]; then
   echo "$SUGGESTIONS" | while IFS= read -r line; do
     # Drop blank lines
     if [ -z "$line" ]; then
@@ -66,77 +154,18 @@ if [ -n "$SUGGESTIONS" ]; then
     # Strip common bullet/number prefixes if the model ignored instructions
     cleaned=$(echo "$line" | sed -E 's/^[[:space:]]*[-*][[:space:]]+//; s/^[[:space:]]*[0-9]+[.)][[:space:]]+//')
 
-    # Remove our own marker emoji if the model included it
-    cleaned=$(echo "$cleaned" | sed 's/💡//g')
-
     echo "# - $cleaned" >> "$COMMIT_MSG_FILE"
   done
-else
-  # Smarter fallback: extract what actually changed
-  # Get list of changed files (without stats)
-  CHANGED_FILES=$(git diff --cached --name-only)
 
-  # Extract key details from the diff
-  ADDED_FUNCS=$(echo "$FULL_DIFF" | grep -E '^\+.*(function|const|export)' | head -3 | sed 's/^+//' | tr '\n' ' ')
-  REMOVED_FUNCS=$(echo "$FULL_DIFF" | grep -E '^-.*(function|const|export)' | head -3 | sed 's/^-//' | tr '\n' ' ')
-
-  # Detect primary change type from paths
-  PRIMARY_PATH=$(echo "$CHANGED_FILES" | head -1)
-
-  # Generate context-aware suggestions
-  if echo "$CHANGED_FILES" | grep -q "commitlint\|husky"; then
-    echo "# - chore: buff the commit hooks for smoother vibes" >> "$COMMIT_MSG_FILE"
-    echo "# - chore: 💅 refine git workflow polish" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "components/"; then
-    COMP_NAME=$(echo "$CHANGED_FILES" | grep "components/" | head -1 | sed 's/.*components\///; s/\.tsx//; s/\.ts//; s/\// /g' | awk '{print $NF}')
-    echo "# - feat: add shimmer to ${COMP_NAME:-components}" >> "$COMMIT_MSG_FILE"
-    echo "# - refactor: 💅 buff ${COMP_NAME:-components} for a smoother finish" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "app/.*page"; then
-    PAGE_NAME=$(echo "$CHANGED_FILES" | grep "page" | head -1 | sed 's/.*app\///; s/\/page\.tsx//; s/\// /g')
-    echo "# - feat: gloss up the ${PAGE_NAME:-page} view" >> "$COMMIT_MSG_FILE"
-    echo "# - feat: ✨ fresh coat on ${PAGE_NAME:-page}" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "functions/"; then
-    FUNC_NAME=$(echo "$CHANGED_FILES" | grep "functions/" | head -1 | sed 's/.*functions\///; s/\.ts//')
-    echo "# - feat: polish the ${FUNC_NAME:-API} endpoint" >> "$COMMIT_MSG_FILE"
-    echo "# - fix: 🔧 cure ${FUNC_NAME:-API} edge cases" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "infrastructure/\|\.tf"; then
-    echo "# - chore: lacquer the infrastructure config" >> "$COMMIT_MSG_FILE"
-    echo "# - chore: 🏗️ buff terraform for a cleaner deploy" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "test"; then
-    echo "# - test: 🧪 nail down edge cases" >> "$COMMIT_MSG_FILE"
-    echo "# - test: add coverage for a chip-free finish" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "\.md\|README"; then
-    echo "# - docs: polish up the readme shine" >> "$COMMIT_MSG_FILE"
-    echo "# - docs: ✨ glossy new documentation" >> "$COMMIT_MSG_FILE"
-  elif echo "$CHANGED_FILES" | grep -q "package.json"; then
-    echo "# - chore: fresh coat on dependencies" >> "$COMMIT_MSG_FILE"
-    echo "# - chore: ✨ update the dependency palette" >> "$COMMIT_MSG_FILE"
-  else
-    # Generic but still try to be specific
-    FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
-    echo "# - feat: buff ${FILE_COUNT} files for a smoother finish" >> "$COMMIT_MSG_FILE"
-    echo "# - refactor: 💅 polish codebase details" >> "$COMMIT_MSG_FILE"
-  fi
-
-  # Always add one that mentions the actual primary file
-  MAIN_FILE=$(basename "$PRIMARY_PATH" | sed 's/\.[^.]*$//')
-  echo "# - feat: ✨ update ${MAIN_FILE} with fresh shine" >> "$COMMIT_MSG_FILE"
-fi
-
-cat >> "$COMMIT_MSG_FILE" << 'EOF'
+  cat >> "$COMMIT_MSG_FILE" << 'EOF'
 #
 # Pick one, customize it, or write your own.
 #
-# Vibe words (optional):
-#   Colors/finishes: shimmer, chrome, glossy, matte, holographic
-#   Manicure verbs: buff, file, coat, cure, polish, swatch
-#   Collection vibes: stash, catalog, inventory, dupe
-#
 # Format: <type>: <subject>
-# Emoji (optional): if you use one, put it in the subject (after <type>: ), e.g.
-#   feat: ✨ add shimmer finish to swatch cards
-#
 # Types: feat, fix, refactor, docs, chore, test, style, perf
 #
 # Write your commit message above (delete all # comment lines)
 EOF
+else
+  write_manual_msg
+fi

--- a/packages/devtools/tests/generate-commit-msg.test.cjs
+++ b/packages/devtools/tests/generate-commit-msg.test.cjs
@@ -10,6 +10,15 @@ const SCRIPT_PATH = path.resolve(
   '../../../.husky/generate-commit-msg.sh'
 );
 
+// Minimal PATH with system essentials (sed, head, etc.) but no claude/curl/jq
+const BARE_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+
+// Clean env for git commands: strip GIT_* vars that leak from pre-commit hooks
+// (e.g. GIT_INDEX_FILE, GIT_DIR) which break temp repo isolation.
+const CLEAN_GIT_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_'))
+);
+
 function exec(cmd, args, options) {
   return execFileSync(cmd, args, {
     encoding: 'utf8',
@@ -19,11 +28,13 @@ function exec(cmd, args, options) {
 }
 
 function git(cwd, ...args) {
-  return exec('git', args, { cwd });
+  return exec('git', args, { cwd, env: CLEAN_GIT_ENV });
 }
 
 async function initRepo() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'swatchwatch-commitmsg-'));
+  const dir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'swatchwatch-commitmsg-')
+  );
   git(dir, 'init');
   git(dir, 'config', 'user.email', 'test@example.com');
   git(dir, 'config', 'user.name', 'Test User');
@@ -37,36 +48,138 @@ async function writeFile(repoDir, relPath, contents) {
   return abs;
 }
 
-test('generate-commit-msg.sh: generates suggestions with emojis after the type', async () => {
-  const repoDir = await initRepo();
-
-  // Stage a change so git diff --cached has output.
+async function stageFile(repoDir) {
   await writeFile(repoDir, 'src/example.ts', 'export const x = 1;\n');
   git(repoDir, 'add', 'src/example.ts');
+}
 
-  // Fake "claude" binary so the script takes the "claude CLI" path.
+/**
+ * Create a fake "claude" binary that outputs canned suggestions.
+ * The fake binary validates it receives the expected -p flag and args.
+ */
+async function makeFakeClaude(repoDir) {
   const binDir = path.join(repoDir, 'bin');
   await fs.mkdir(binDir, { recursive: true });
 
-  const promptCaptureFile = path.join(repoDir, 'prompt.txt');
+  const argCaptureFile = path.join(repoDir, 'claude-args.txt');
   const claudePath = path.join(binDir, 'claude');
+  // Capture all args so we can verify flags. Output 3 canned suggestions.
   await fs.writeFile(
     claudePath,
-    `#!/usr/bin/env sh\ncat > "${promptCaptureFile}"\ncat >/dev/null\nprintf "%s\\n" \\\n  "feat: ✨ add shimmer finish to swatch cards" \\\n  "fix: polish swatch rendering edge cases" \\\n  "docs: add glossy API notes 💅"\n`
+    [
+      '#!/usr/bin/env sh',
+      `printf "%s\\n" "$@" > "${argCaptureFile}"`,
+      'printf "%s\\n" \\',
+      '  "feat: ✨ add shimmer finish to swatch cards" \\',
+      '  "fix: polish swatch rendering edge cases" \\',
+      '  "docs: add glossy API notes 💅"',
+    ].join('\n') + '\n'
   );
   exec('chmod', ['+x', claudePath], { cwd: repoDir });
+
+  return { binDir, argCaptureFile };
+}
+
+/**
+ * Find the system jq binary path, or null if not installed.
+ */
+function findJq() {
+  try {
+    return exec('which', ['jq']).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a fake "curl" that returns a canned API response.
+ * Also symlinks real jq into binDir so the PATH stays isolated
+ * (no extra dirs that might contain claude).
+ */
+async function makeFakeCurl(repoDir, { format = 'anthropic' } = {}) {
+  const binDir = path.join(repoDir, 'bin');
+  await fs.mkdir(binDir, { recursive: true });
+
+  // Symlink real jq into our isolated binDir
+  const jqPath = findJq();
+  if (jqPath) {
+    const jqLink = path.join(binDir, 'jq');
+    try { await fs.symlink(jqPath, jqLink); } catch { /* already exists */ }
+  }
+
+  const urlCaptureFile = path.join(repoDir, 'curl-url.txt');
+  const curlPath = path.join(binDir, 'curl');
+
+  let jsonResponse;
+  if (format === 'anthropic') {
+    jsonResponse = JSON.stringify({
+      content: [
+        {
+          text: [
+            'feat: ✨ add shimmer finish to swatch cards',
+            'fix: polish swatch rendering edge cases',
+            'docs: add glossy API notes 💅',
+          ].join('\n'),
+        },
+      ],
+    });
+  } else {
+    // openai format
+    jsonResponse = JSON.stringify({
+      choices: [
+        {
+          message: {
+            content: [
+              'feat: ✨ add shimmer finish to swatch cards',
+              'fix: polish swatch rendering edge cases',
+              'docs: add glossy API notes 💅',
+            ].join('\n'),
+          },
+        },
+      ],
+    });
+  }
+
+  // Capture all args so we can verify the URL; output canned JSON
+  await fs.writeFile(
+    curlPath,
+    [
+      '#!/usr/bin/env sh',
+      `printf "%s\\n" "$@" > "${urlCaptureFile}"`,
+      `printf '%s' '${jsonResponse.replace(/'/g, "'\\''")}'`,
+    ].join('\n') + '\n'
+  );
+  exec('chmod', ['+x', curlPath], { cwd: repoDir });
+
+  return { binDir, urlCaptureFile };
+}
+
+// --- Tests ---
+
+test('Claude CLI provider: uses claude -p with correct flags', async () => {
+  const repoDir = await initRepo();
+  await stageFile(repoDir);
+  const { binDir, argCaptureFile } = await makeFakeClaude(repoDir);
 
   const commitMsgFile = path.join(repoDir, 'COMMIT_EDITMSG');
 
   exec('sh', [SCRIPT_PATH, commitMsgFile], {
     cwd: repoDir,
     env: {
-      ...process.env,
-      PATH: `${binDir}:${process.env.PATH}`,
-      ANTHROPIC_API_KEY: 'test_key',
+      PATH: `${binDir}:${BARE_PATH}`,
+      HOME: os.homedir(),
     },
   });
 
+  // Verify claude was called with expected flags
+  const capturedArgs = await fs.readFile(argCaptureFile, 'utf8');
+  assert.match(capturedArgs, /-p/);
+  assert.match(capturedArgs, /--model/);
+  assert.match(capturedArgs, /haiku/);
+  assert.match(capturedArgs, /--max-turns/);
+  assert.match(capturedArgs, /1/);
+
+  // Verify output has suggestions
   const out = await fs.readFile(commitMsgFile, 'utf8');
   const suggestionLines = out
     .split('\n')
@@ -74,40 +187,157 @@ test('generate-commit-msg.sh: generates suggestions with emojis after the type',
     .map((l) => l.replace(/^# - /, '').trim());
 
   assert.equal(suggestionLines.length, 3);
-
   for (const line of suggestionLines) {
     assert.match(line, /^(feat|fix|refactor|docs|chore|test|style): /);
-    // Ensure no emoji appears before the type prefix.
-    assert.doesNotMatch(line, /^[^:]*[✨💅].*:/);
   }
 
-  const prompt = await fs.readFile(promptCaptureFile, 'utf8');
-  assert.match(prompt, /vibey Conventional Commit suggestions/i);
-  assert.match(prompt, /Never put emoji before the type/i);
-  assert.match(prompt, /after <type>: \)/i);
+  // Verify provider label
+  assert.match(out, /claude-cli/);
 });
 
-test('generate-commit-msg.sh: generates fallback suggestions for package.json changes', async () => {
+test('Anthropic API provider: used when no claude CLI but ANTHROPIC_API_KEY set', async () => {
   const repoDir = await initRepo();
+  await stageFile(repoDir);
 
-  await writeFile(repoDir, 'package.json', '{"name":"tmp"}\n');
-  git(repoDir, 'add', 'package.json');
+  if (!findJq()) return; // skip if jq not installed
+
+  // binDir has fake curl + symlinked jq, but NO claude
+  const { binDir, urlCaptureFile } = await makeFakeCurl(repoDir, {
+    format: 'anthropic',
+  });
 
   const commitMsgFile = path.join(repoDir, 'COMMIT_EDITMSG');
 
-  // Force the fallback branch by ensuring we have no Anthropic API key and no "claude" in PATH.
   exec('sh', [SCRIPT_PATH, commitMsgFile], {
     cwd: repoDir,
     env: {
-      ...process.env,
-      ANTHROPIC_API_KEY: '',
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
+      PATH: `${binDir}:${BARE_PATH}`,
+      HOME: os.homedir(),
+      ANTHROPIC_API_KEY: 'sk-test-key',
+    },
+  });
+
+  // Verify curl was called with Anthropic URL
+  const capturedUrl = await fs.readFile(urlCaptureFile, 'utf8');
+  assert.match(capturedUrl, /api\.anthropic\.com/);
+
+  // Verify output
+  const out = await fs.readFile(commitMsgFile, 'utf8');
+  assert.match(out, /anthropic-api/);
+  const suggestionLines = out
+    .split('\n')
+    .filter((l) => l.startsWith('# - '));
+  assert.equal(suggestionLines.length, 3);
+});
+
+test('OpenAI API provider: used when no claude CLI, no ANTHROPIC_API_KEY, but OPENAI_API_KEY set', async () => {
+  const repoDir = await initRepo();
+  await stageFile(repoDir);
+
+  if (!findJq()) return; // skip if jq not installed
+
+  // binDir has fake curl + symlinked jq, but NO claude
+  const { binDir, urlCaptureFile } = await makeFakeCurl(repoDir, {
+    format: 'openai',
+  });
+
+  const commitMsgFile = path.join(repoDir, 'COMMIT_EDITMSG');
+
+  exec('sh', [SCRIPT_PATH, commitMsgFile], {
+    cwd: repoDir,
+    env: {
+      PATH: `${binDir}:${BARE_PATH}`,
+      HOME: os.homedir(),
+      OPENAI_API_KEY: 'sk-test-key',
+    },
+  });
+
+  // Verify curl was called with OpenAI URL
+  const capturedUrl = await fs.readFile(urlCaptureFile, 'utf8');
+  assert.match(capturedUrl, /api\.openai\.com/);
+
+  // Verify output
+  const out = await fs.readFile(commitMsgFile, 'utf8');
+  assert.match(out, /openai-api/);
+  const suggestionLines = out
+    .split('\n')
+    .filter((l) => l.startsWith('# - '));
+  assert.equal(suggestionLines.length, 3);
+});
+
+test('Manual fallback: no AI available produces write-your-own message', async () => {
+  const repoDir = await initRepo();
+  await stageFile(repoDir);
+
+  const commitMsgFile = path.join(repoDir, 'COMMIT_EDITMSG');
+
+  // No claude in PATH, no API keys
+  exec('sh', [SCRIPT_PATH, commitMsgFile], {
+    cwd: repoDir,
+    env: {
+      PATH: BARE_PATH,
+      HOME: os.homedir(),
     },
   });
 
   const out = await fs.readFile(commitMsgFile, 'utf8');
-  // Should generate package.json-aware suggestions
-  assert.match(out, /# - chore:.*dependenc/i);
-  // Should also include a suggestion mentioning the actual file
-  assert.match(out, /package/i);
+
+  // Should NOT have any suggestion lines
+  const suggestionLines = out
+    .split('\n')
+    .filter((l) => l.startsWith('# - '));
+  assert.equal(suggestionLines.length, 0, 'Manual fallback should not generate suggestions');
+
+  // Should have the "no AI provider" message
+  assert.match(out, /No AI provider available/);
+  assert.match(out, /write your commit message/i);
+
+  // Should mention setup options
+  assert.match(out, /Claude Code CLI/);
+  assert.match(out, /Anthropic API key/);
+  assert.match(out, /OpenAI API key/);
+});
+
+test('Claude CLI fallback: falls through to next provider on failure', async () => {
+  const repoDir = await initRepo();
+  await stageFile(repoDir);
+
+  // Create a claude binary that fails (exits non-zero with no output)
+  const binDir = path.join(repoDir, 'bin');
+  await fs.mkdir(binDir, { recursive: true });
+  const claudePath = path.join(binDir, 'claude');
+  await fs.writeFile(claudePath, '#!/usr/bin/env sh\nexit 1\n');
+  exec('chmod', ['+x', claudePath], { cwd: repoDir });
+
+  const commitMsgFile = path.join(repoDir, 'COMMIT_EDITMSG');
+
+  // Claude CLI will fail, no API keys → should fall to manual
+  exec('sh', [SCRIPT_PATH, commitMsgFile], {
+    cwd: repoDir,
+    env: {
+      PATH: `${binDir}:${BARE_PATH}`,
+      HOME: os.homedir(),
+    },
+  });
+
+  const out = await fs.readFile(commitMsgFile, 'utf8');
+  assert.match(out, /No AI provider available/);
+});
+
+test('No staged changes: outputs informational comment only', async () => {
+  const repoDir = await initRepo();
+
+  const commitMsgFile = path.join(repoDir, 'COMMIT_EDITMSG');
+  await fs.writeFile(commitMsgFile, '');
+
+  exec('sh', [SCRIPT_PATH, commitMsgFile], {
+    cwd: repoDir,
+    env: {
+      PATH: BARE_PATH,
+      HOME: os.homedir(),
+    },
+  });
+
+  const out = await fs.readFile(commitMsgFile, 'utf8');
+  assert.match(out, /No staged changes/);
 });


### PR DESCRIPTION
## Summary
- Refactors `prepare-commit-msg` hook with a provider cascade: Claude CLI → Anthropic API → OpenAI API → manual fallback
- Checks exit codes so failed providers fall through cleanly instead of treating error output as suggestions
- Replaces old pattern-based stub suggestions with honest "write your own" message when no AI is available
- Tests sanitize `GIT_*` env vars for reliable execution inside git hooks

Closes #5

## Test plan
- [x] All 8 devtools tests pass (Claude CLI, Anthropic API, OpenAI API, manual fallback, CLI failure fallthrough, no staged changes)
- [ ] Manual test: `PATH="/usr/bin:/bin" sh .husky/generate-commit-msg.sh /tmp/test-msg && cat /tmp/test-msg` shows "write your own"
- [ ] Manual test: stage a change and `git commit` with Claude CLI installed → AI suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)