### PR TITLE
refactor: move product color data from user_inventory_item to shade

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -53,6 +53,10 @@ CREATE TABLE shade (
   collection TEXT,
   release_year INT,
   status TEXT NOT NULL DEFAULT 'unknown',
+  color_name TEXT,
+  vendor_hex TEXT,
+  detected_hex TEXT,
+  name_hex TEXT,
   UNIQUE (brand_id, product_line_id, shade_name_canonical, COALESCE(finish,''))
 );
 

--- a/packages/functions/migrations/012_move_color_data_to_shade.sql
+++ b/packages/functions/migrations/012_move_color_data_to_shade.sql
@@ -1,0 +1,45 @@
+-- Migration 012: Move product-level color data from user_inventory_item to shade
+--
+-- color_name, vendor_hex, detected_hex, name_hex describe the PRODUCT, not the
+-- user's relationship with it.  They belong on the canonical shade table.
+
+-- UP: Add color columns to shade
+ALTER TABLE shade ADD COLUMN IF NOT EXISTS color_name TEXT;
+ALTER TABLE shade ADD COLUMN IF NOT EXISTS vendor_hex TEXT;
+ALTER TABLE shade ADD COLUMN IF NOT EXISTS detected_hex TEXT;
+ALTER TABLE shade ADD COLUMN IF NOT EXISTS name_hex TEXT;
+
+-- Populate shade from inventory (prefer rows with most color data, most recent)
+UPDATE shade s
+SET
+  color_name   = COALESCE(s.color_name,   src.color_name),
+  vendor_hex   = COALESCE(s.vendor_hex,   src.vendor_hex),
+  detected_hex = COALESCE(s.detected_hex, src.detected_hex),
+  name_hex     = COALESCE(s.name_hex,     src.name_hex)
+FROM (
+  SELECT DISTINCT ON (shade_id)
+    shade_id, color_name, vendor_hex, detected_hex, name_hex
+  FROM user_inventory_item
+  WHERE shade_id IS NOT NULL
+  ORDER BY shade_id,
+    (CASE WHEN vendor_hex IS NOT NULL THEN 1 ELSE 0 END
+     + CASE WHEN detected_hex IS NOT NULL THEN 1 ELSE 0 END
+     + CASE WHEN name_hex IS NOT NULL THEN 1 ELSE 0 END
+     + CASE WHEN color_name IS NOT NULL THEN 1 ELSE 0 END) DESC,
+    updated_at DESC NULLS LAST
+) src
+WHERE s.shade_id = src.shade_id;
+
+-- Drop deprecated columns from user_inventory_item
+ALTER TABLE user_inventory_item DROP COLUMN IF EXISTS color_name;
+ALTER TABLE user_inventory_item DROP COLUMN IF EXISTS vendor_hex;
+ALTER TABLE user_inventory_item DROP COLUMN IF EXISTS detected_hex;
+ALTER TABLE user_inventory_item DROP COLUMN IF EXISTS name_hex;
+
+-- DOWN:
+-- ALTER TABLE user_inventory_item ADD COLUMN color_name TEXT;
+-- ALTER TABLE user_inventory_item ADD COLUMN vendor_hex TEXT;
+-- ALTER TABLE user_inventory_item ADD COLUMN detected_hex TEXT;
+-- ALTER TABLE user_inventory_item ADD COLUMN name_hex TEXT;
+-- UPDATE user_inventory_item ui SET color_name = s.color_name, vendor_hex = s.vendor_hex, detected_hex = s.detected_hex, name_hex = s.name_hex FROM shade s WHERE ui.shade_id = s.shade_id;
+-- ALTER TABLE shade DROP COLUMN color_name, DROP COLUMN vendor_hex, DROP COLUMN detected_hex, DROP COLUMN name_hex;

--- a/packages/shared/src/types/polish.ts
+++ b/packages/shared/src/types/polish.ts
@@ -68,6 +68,10 @@ export interface Shade {
   collection?: string;
   release_year?: number;
   status: string;
+  color_name?: string;
+  vendor_hex?: string;
+  detected_hex?: string;
+  name_hex?: string;
 }
 
 export interface PolishCreateRequest {


### PR DESCRIPTION
## Summary

- **Moves `color_name`, `vendor_hex`, `detected_hex`, `name_hex` from `user_inventory_item` to `shade`** — these fields describe the product, not the user's relationship with it, and were being duplicated per-user
- Migration 012 adds the columns to `shade`, copies existing data, and drops the old columns from `user_inventory_item`
- All handlers (`polishes.ts`) and ingestion materializers (`ingestion-repo.ts`) now read/write color data on `shade`
- **API contract (`Polish` type) is unchanged** — no frontend changes needed

## Files changed

| File | Change |
|------|--------|
| `packages/functions/migrations/012_move_color_data_to_shade.sql` | New migration |
| `packages/functions/src/functions/polishes.ts` | SELECT, findOrCreateShade, create, update |
| `packages/functions/src/lib/ingestion-repo.ts` | MakeupAPI + HoloTaco materializers |
| `packages/shared/src/types/polish.ts` | Add color fields to `Shade` interface |
| `docs/schema.sql` | Add color columns to shade DDL |

## Test plan

- [ ] Run migration 012 against dev database and verify data moved correctly
- [ ] `GET /api/polishes` returns same shape with color data sourced from shade
- [ ] `POST /api/polishes` writes color data to shade, not inventory
- [ ] `PUT /api/polishes/{id}` updates shade table for color fields
- [ ] Search by color name still works
- [ ] Ingestion jobs (MakeupAPI, Shopify) write color data to shade
- [ ] Web app displays correctly with no frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)