### PR TITLE
fix: add unique constraint for user_inventory_item upsert

### DIFF
--- a/packages/functions/migrations/014_add_user_inventory_unique_constraint.sql
+++ b/packages/functions/migrations/014_add_user_inventory_unique_constraint.sql
@@ -1,0 +1,11 @@
+-- Migration: Add unique constraint for user_inventory_item upsert operations
+--
+-- Problem: The ON CONFLICT upsert in polishes.ts uses (user_id, shade_id),
+-- but only a partial unique index exists (WHERE shade_id IS NOT NULL).
+-- ON CONFLICT requires a full constraint matching the conflict target.
+--
+-- Solution: Add a proper UNIQUE constraint on (user_id, shade_id).
+-- The partial index is kept for performance on filtered queries.
+
+ALTER TABLE user_inventory_item
+ADD CONSTRAINT uq_user_inventory_shade UNIQUE (user_id, shade_id);


### PR DESCRIPTION
## Summary
Fixes the `ON CONFLICT` upsert error when adding/updating polish quantities on `/polishes`.

**Root Cause:** The polishes endpoint uses `ON CONFLICT (user_id, shade_id) DO UPDATE` to upsert inventory items, but the database only had a partial unique index (`WHERE shade_id IS NOT NULL`). PostgreSQL's `ON CONFLICT` requires a full constraint matching the conflict target.

**Solution:** Add a proper `UNIQUE` constraint on `(user_id, shade_id)`. The partial index is retained for performance on filtered queries.

## Changes
- Added migration `014_add_user_inventory_unique_constraint.sql` to create the constraint

## Closes
Fixes #42 (DB constraint error when adding/updating polish quantity)

## Test Plan
- Run local dev stack with migrations: `npm run dev:infra` then `npm run migrate`
- Open `/polishes` and test add-to-collection quantity updates
- Verify operations succeed without 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved data integrity for user inventory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->