### PR TITLE
feat(web): add admin hex recalculation controls to polishes table

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,7 +25,7 @@ src/app/
 │   │   ├── page.tsx              → /dashboard       Stats, recent additions (computed from full paginated inventory)
 │   │   └── opengraph-image.tsx   → /dashboard OG image route
 │   └── polishes/
-│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; swatch thumbnails open full image)
+│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
 │       ├── opengraph-image.tsx   → /polishes OG image route
 │       ├── new/page.tsx          → /polishes/new     Add polish form
 │       ├── [id]/page.tsx         → /polishes/:id     Polish detail view + image preview + OKLCH profile + related shades
@@ -136,8 +136,9 @@ cd apps/web && npx shadcn@latest add <component-name>
 - `<UserCard>` displays user info and sign-out button in sidebar
 
 **Hooks:**
-- `useAuth()` — B2C mode only, calls MSAL hooks (`useMsal`, `useIsAuthenticated`). Returns `{ isAuthenticated, user, login, logout }`. Must be inside `<MsalProvider>`
-- `useDevAuth()` — Dev bypass stub, safe to call anywhere. Returns stubbed auth state
+- `useAuth()` — B2C mode only, calls MSAL hooks (`useMsal`, `useIsAuthenticated`). Returns `{ isAuthenticated, user, role, isAdmin, login, logout }`. Must be inside `<MsalProvider>`
+- `useDevAuth()` — Dev bypass stub, safe to call anywhere. Returns stubbed auth state with admin role for local testing
+- `useUnconfiguredAuth()` — B2C-unconfigured stub, safe to call anywhere. Returns unauthenticated non-admin state
 
 ## Utilities (`src/lib/`)
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -142,6 +142,21 @@ export async function deletePolish(id: string | number): Promise<{ message: stri
   return handleResponse<{ message: string; id: number }>(response);
 }
 
+export interface RecalcPolishHexResponse {
+  success?: boolean;
+  message?: string;
+  shadeId?: string;
+  status?: string;
+}
+
+export async function recalcPolishHex(id: string | number): Promise<RecalcPolishHexResponse> {
+  const response = await fetch(`${API_BASE_URL}/polishes/${id}/recalc-hex`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...getAuthHeaders({ admin: true }) },
+  });
+  return handleResponse<RecalcPolishHexResponse>(response);
+}
+
 export async function searchCatalog(q: string, limit?: number): Promise<CatalogSearchResponse> {
   const params = new URLSearchParams({ q });
   if (limit) params.set("limit", String(limit));


### PR DESCRIPTION
## Summary
- add role awareness to web auth hooks (`role`, `isAdmin`) and derive admin from MSAL role claims
- add API client helper for `POST /api/polishes/{id}/recalc-hex`
- add admin-only `Recalc Hex` column and per-row action button on `/polishes`
- add row-level submitting state and toast feedback for success/failure
- document updated `/polishes` behavior and hook return contract in `apps/web/README.md`

## Validation
- `npm run lint --workspace=apps/web` (warnings only, no errors)
- `npm run build:web`

## Notes
- This UI expects the backend admin recalc endpoint (`/api/polishes/{id}/recalc-hex`) to be available in the target environment.

Closes #42
