### PR TITLE
feat(web): gate admin navigation and jobs page by role

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,7 +19,7 @@ src/app/
 │   └── page.tsx                  → /           Landing page (hero, features, interactive showcase, testimonials, CTA)
 ├── (app)/
 │   ├── layout.tsx                → App layout (AppShell sidebar wrapper)
-│   ├── admin/jobs/page.tsx       → /admin/jobs      Internal ingestion admin (run jobs, toggle AI hex detection/overwrite mode, track status/metrics)
+│   ├── admin/jobs/page.tsx       → /admin/jobs      Internal ingestion admin (admin-only UI guard; run jobs, toggle AI hex detection/overwrite mode, track status/metrics)
 │   ├── dashboard/page.tsx        → /dashboard       Stats, recent additions (computed from full paginated inventory)
 │   ├── dashboard/
 │   │   ├── page.tsx              → /dashboard       Stats, recent additions (computed from full paginated inventory)
@@ -93,7 +93,7 @@ Shared heading scale utilities are defined in `src/app/globals.css` and reused a
 
 | Component | Purpose |
 |-----------|---------|
-| `app-shell.tsx` | Sidebar navigation (desktop) + header nav (mobile) with exact active-route matching, branded active-nav pills, logo accent divider, app theme toggle, and `<UserCard>` footer with auth state |
+| `app-shell.tsx` | Sidebar navigation (desktop) + header nav (mobile) with exact active-route matching, branded active-nav pills, logo accent divider, app theme toggle, and `<UserCard>` footer with auth state. Admin links are shown only for admin users |
 | `auth-provider.tsx` | MSAL provider wrapper with three modes: dev bypass (no MSAL), B2C via MSAL, unconfigured fallback. Manages token lifecycle and stores in module-level `auth-token.ts` |
 | `require-auth.tsx` | Route guard for `(app)` routes. Dev bypass → render children; B2C unconfigured → show "Sign in" button; B2C authenticated → render children; unauthenticated → show "Sign in" button |
 | `user-card.tsx` | Sidebar footer: displays user initials, name, email, and sign-out button. Conditionally uses `useAuth()` (B2C) or `useDevAuth()` (dev bypass) |

--- a/apps/web/src/app/(app)/admin/jobs/page.tsx
+++ b/apps/web/src/app/(app)/admin/jobs/page.tsx
@@ -66,8 +66,49 @@ import {
   Settings,
 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
+import { useAuth, useDevAuth, useUnconfiguredAuth } from "@/hooks/use-auth";
+import { buildMsalConfig } from "@/lib/msal-config";
 
 type SourceFilter = "all" | string;
+const IS_DEV_BYPASS = process.env.NEXT_PUBLIC_AUTH_DEV_BYPASS === "true";
+const HAS_B2C_CONFIG = buildMsalConfig() !== null;
+
+export default function AdminJobsPage() {
+  if (IS_DEV_BYPASS) {
+    return <DevAdminJobsPage />;
+  }
+
+  if (!HAS_B2C_CONFIG) {
+    return <UnconfiguredAdminJobsPage />;
+  }
+
+  return <B2CAdminJobsPage />;
+}
+
+function DevAdminJobsPage() {
+  const { isAdmin } = useDevAuth();
+  return isAdmin ? <AdminJobsInner /> : <AdminAccessRequired />;
+}
+
+function B2CAdminJobsPage() {
+  const { isAdmin } = useAuth();
+  return isAdmin ? <AdminJobsInner /> : <AdminAccessRequired />;
+}
+
+function UnconfiguredAdminJobsPage() {
+  const { isAdmin } = useUnconfiguredAuth();
+  return isAdmin ? <AdminJobsInner /> : <AdminAccessRequired />;
+}
+
+function AdminAccessRequired() {
+  return (
+    <ErrorState
+      title="Admin Access Required"
+      message="This page is only available to admin users."
+      className="min-h-[420px]"
+    />
+  );
+}
 
 
 
@@ -264,7 +305,7 @@ function JobLogPanel({ job, autoScroll }: { job: IngestionJobRecord; autoScroll?
   );
 }
 
-export default function AdminJobsPage() {
+function AdminJobsInner() {
   const [jobs, setJobs] = useState<IngestionJobRecord[]>([]);
   const [totalJobs, setTotalJobs] = useState(0);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- hide the `Admin Jobs` nav link for non-admin users in the app shell
- add an explicit admin-only guard state on `/admin/jobs` for non-admin users
- preserve existing dev-bypass behavior for local admin workflows
- update `apps/web/README.md` to document admin-only navigation and route behavior

## Validation
- npm run lint --workspace=apps/web (warnings only)
- npm run build:web

Part of #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated admin features descriptions in documentation

* **Chores**
  * Restructured admin jobs interface to support environment-based routing
  * Improved admin navigation to display conditionally based on user authorization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->