### PR TITLE
feat(web): persist polishes list state for back navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ This project is in early development. The web UI is now fully API-driven. See [K
 | [This README](README.md) | All developers | Setup, architecture, quick start |
 | [CLAUDE.md](CLAUDE.md) | AI coding agents | Conventions, patterns, decision rationale (canonical; other agent files are symlinks) |
 | [apps/web/README.md](apps/web/README.md) | Web developers | Web app architecture, components, routing |
+| [docs/issue-42-ui-findings-tracker.md](docs/issue-42-ui-findings-tracker.md) | Web + product | Live tracker for Issue #42 UI findings and implementation status |
 | [packages/functions/README.md](packages/functions/README.md) | Backend developers | API routes, handler patterns, local dev |
 | [packages/shared/README.md](packages/shared/README.md) | All developers | Shared types, how to add new types |
 | [infrastructure/README.md](infrastructure/README.md) | DevOps / infra | Terraform resources, provisioning, variables |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,7 +25,7 @@ src/app/
 │   │   ├── page.tsx              → /dashboard       Stats, recent additions (computed from full paginated inventory)
 │   │   └── opengraph-image.tsx   → /dashboard OG image route
 │   └── polishes/
-│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
+│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; persists page/filter/sort state in URL query params for back-navigation restore; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
 │       ├── opengraph-image.tsx   → /polishes OG image route
 │       ├── new/page.tsx          → /polishes/new     Add polish form
 │       ├── [id]/page.tsx         → /polishes/:id     Polish detail view + image preview + OKLCH profile + related shades

--- a/docs/issue-42-ui-findings-tracker.md
+++ b/docs/issue-42-ui-findings-tracker.md
@@ -1,0 +1,29 @@
+# Issue #42 UI Findings Tracker
+
+Source: GitHub issue "Tonight: UI issues log (pre-M0)" (#42) text provided in chat on 2026-02-19.
+
+This tracker captures the findings visible in that shared issue text and maps them to implementation status in `dev`.
+
+## Status Legend
+- `Done` = implemented and merged to `dev`
+- `Pending` = not implemented yet
+- `Verify` = likely implemented but should be explicitly validated in UI
+
+## Findings
+
+| ID | Route | Severity | Finding | Status | Notes / References |
+|---|---|---|---|---|---|
+| 1 | `/polishes` | medium | Add first/last and +/-5 page jump pagination controls | Done | Implemented in pagination updates merged via #60 / #62 |
+| 2 | `/polishes` | medium | Add rows-per-page selector (25/50/100 etc.) | Done | Implemented in pagination UI and page state via #60 / #62 |
+| 3 | `/polishes` quantity update | high | 500 on upsert due missing unique conflict target | Done | DB unique constraint fix merged via #60 / #62 |
+| 4 | `/polishes` admin UX | medium | Admin-only per-row hex recalculation action with feedback | Done | UI action merged in #63; backend endpoint merged via #61 |
+| 5 | `/polishes` back navigation | medium | Preserve page/list context when returning from detail/edit | Done | Implemented in `feat/42-ui-final-slice`: list state now persists in URL query params (page, pageSize, filters, sort) |
+| 6 | `/polishes` action alignment | low | Add button alignment inconsistent with quantity controls | Verify | Current action cell is right-aligned; confirm visual consistency in latest UI |
+| 7 | `/polishes` table headers | high | Image column header missing/misaligned | Done | Fixed in #60 / #62 |
+| 8 | `/polishes` finish/collection overflow | medium | Keep single-line pills, ellipsis, hover reveal full set | Pending | Needs tooltip/popover pattern and stable row height |
+| 9 | `/polishes` + `/polishes/search` filters | medium | Standardize dropdown fields/options (include brand) | Pending | Requested consistency across both routes |
+| 10 | `/polishes` + `/polishes/search` collection toggle | medium | Replace dual buttons with clearer All/My Collection model | Pending | Candidate for shared reusable filter bar |
+
+## Notes
+- The issue page excerpt indicated "15 remaining items" not fully included in the pasted text.
+- If additional findings exist in the full issue thread, append them here before implementation.


### PR DESCRIPTION
## Summary
- persist /polishes list state in URL query params so back/forward navigation restores context
- restore and sync page, page size, search, sort, and filter state from query params
- clamp invalid/out-of-range page values after filtering
- add docs tracker for Issue #42 findings and current status in docs/issue-42-ui-findings-tracker.md
- update web and root docs to reflect the new route behavior and tracker

## Validation
- npm run lint --workspace=apps/web (warnings only)
- npm run build:web

Part of #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polishes page now preserves filter, sort, and pagination state in the URL, enabling back-navigation restoration.

* **Documentation**
  * Added Issue #42 UI findings tracker documentation with severity levels and status tracking.
  * Updated README with state persistence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->