### PR TITLE
fix(functions): restore recalc-hex endpoint to resolve 404

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -24,6 +24,7 @@ Requires **Azure Functions Core Tools v4** (`npm i -g azure-functions-core-tools
 | `POST` | `/api/polishes` | `createPolish` | `polishes.ts` | ✅ Live |
 | `PUT` | `/api/polishes/{id}` | `updatePolish` | `polishes.ts` | ✅ Live |
 | `DELETE` | `/api/polishes/{id}` | `deletePolish` | `polishes.ts` | ✅ Live |
+| `POST` | `/api/polishes/{id}/recalc-hex` | `recalcHex` | `polishes.ts` | ✅ Live (admin-only) |
 | `POST` | `/api/auth/validate` | `validateToken` | `auth.ts` | ✅ Working |
 | `GET` | `/api/auth/config` | `getAuthConfig` | `auth.ts` | ✅ Working |
 | `GET` | `/api/ingestion/jobs` | `ingestionJobsHandler` | `ingestion.ts` | ✅ Working |
@@ -37,6 +38,7 @@ All handlers return `Promise<HttpResponseInit>` and accept `(request: HttpReques
 
 `GET /api/polishes` now returns the entire canonical shade catalog joined with the requesting user's inventory rows. `inventoryItemId` and user-facing fields are undefined when the user has not added that shade yet, but catalog metadata (brand, finish, color hexes, swatch) is still returned so the UI can show "not owned" entries. `GET /api/polishes/{id}` looks up a shade by `shade_id` and includes `sourceImageUrls` (all source images associated with that shade's swatches) for the detail page.
 For private blob storage, the API rewrites blob URLs to `/api/images/{id}` so image bytes are served through Functions (no public container access or client-side SAS required).
+`POST /api/polishes/{id}/recalc-hex` is admin-only and currently returns a `202` queued response after validating the shade exists (AI recalculation integration remains TODO).
 
 ### Connector Ingestion Jobs
 


### PR DESCRIPTION
## Summary
- restore missing backend route `POST /api/polishes/{id}/recalc-hex` in `packages/functions/src/functions/polishes.ts`
- guard endpoint with `withAdmin` + `withCors` to match existing admin API behavior
- return `202` queued response after validating the shade exists (stub behavior maintained)
- update `packages/functions/README.md` API route table and notes for the recalc endpoint

## Root Cause
The web client shipped admin recalc controls, but current `dev` backend did not register the recalc endpoint, so requests hit a true Function App 404.

## Validation
- `npm run build:functions`

Fixes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-only endpoint to trigger hex color recalculation for polish items with asynchronous processing (queued status).

* **Documentation**
  * Updated API documentation with new admin-only recalculation endpoint details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->