### PR TITLE
refactor(web): use next image for swatch thumbnails

### DIFF
--- a/apps/web/src/app/(app)/polishes/detail/polish-detail-client.tsx
+++ b/apps/web/src/app/(app)/polishes/detail/polish-detail-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import type { Polish } from "swatchwatch-shared";
 import { resolveDisplayHex } from "swatchwatch-shared";
@@ -307,15 +308,15 @@ export default function PolishDetailClient({ id }: { id: string }) {
                       target="_blank"
                       rel="noreferrer"
                       title="Open image"
-                      className="inline-block"
+                      className="relative inline-block h-36 w-full overflow-hidden rounded-lg border"
                     >
-                      {/* Dynamic external image URLs + static export require raw img here. */}
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
+                      <Image
                         src={imageUrl}
                         alt={`${polish.brand} ${polish.name} image ${index + 1}`}
-                        className="h-36 w-full rounded-lg border object-cover transition-opacity hover:opacity-90"
-                        loading="lazy"
+                        fill
+                        unoptimized
+                        sizes="(min-width: 640px) 33vw, 50vw"
+                        className="object-cover transition-opacity hover:opacity-90"
                       />
                     </a>
                   ))}

--- a/apps/web/src/app/(app)/polishes/page.tsx
+++ b/apps/web/src/app/(app)/polishes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { Polish } from "swatchwatch-shared";
 import { resolveDisplayHex } from "swatchwatch-shared";
@@ -624,13 +625,14 @@ function PolishesPageContent({ isAdmin }: { isAdmin: boolean }) {
                           title="Open image"
                           className="inline-block"
                         >
-                          {/* Dynamic external image URLs + static export require raw img here. */}
-                          {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img
+                          <Image
                             src={polish.swatchImageUrl}
                             alt={`${polish.brand} ${polish.name} swatch`}
+                            width={40}
+                            height={40}
+                            unoptimized
+                            sizes="40px"
                             className="h-10 w-10 rounded-md border object-cover transition-opacity hover:opacity-85"
-                            loading="lazy"
                           />
                         </a>
                       ) : (

--- a/apps/web/src/components/color-search-results.tsx
+++ b/apps/web/src/components/color-search-results.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import type { Polish } from "swatchwatch-shared";
 import { resolveDisplayHex } from "swatchwatch-shared";
 import { BsPlusLg } from "react-icons/bs";
@@ -93,13 +94,14 @@ export function ColorSearchResults({
               className="flex min-w-0 flex-1 items-center gap-3"
             >
               {polish.swatchImageUrl ? (
-                // Dynamic external image URLs + static export require raw img here.
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
+                <Image
                   src={polish.swatchImageUrl}
                   alt={`${polish.brand} ${polish.name} swatch`}
+                  width={40}
+                  height={40}
+                  unoptimized
+                  sizes="40px"
                   className="h-10 w-10 shrink-0 rounded-md border object-cover transition-opacity hover:opacity-85"
-                  loading="lazy"
                 />
               ) : (
                 <div className="h-10 w-10 shrink-0 rounded-md border bg-muted/40" />

--- a/docs/issue-42-ui-findings-tracker.md
+++ b/docs/issue-42-ui-findings-tracker.md
@@ -27,4 +27,4 @@ This tracker captures the findings visible in that shared issue text and maps th
 ## Notes
 - The issue page excerpt indicated "15 remaining items" not fully included in the pasted text.
 - If additional findings exist in the full issue thread, append them here before implementation.
-- 2026-02-19: CI lint follow-up in `fix/42-no-img-lint` documented intentional raw `<img>` usage for dynamic external swatch URLs in static export mode to clear `@next/next/no-img-element` warnings.
+- 2026-02-19: CI lint follow-up in `fix/42-no-img-lint` migrated three swatch-image call sites to `next/image` with `unoptimized` for static-export compatibility and dynamic external URLs.


### PR DESCRIPTION
Summary:\n- replace three raw swatch image tags with next/image in polishes list/detail/search UI\n- use unoptimized for static-export compatibility with dynamic external image URLs\n- keep existing sizing/visual behavior and link-to-original-image behavior\n- update Issue #42 tracker note with the final implementation\n\nValidation:\n- npm run lint --workspace=apps/web\n- no next no-img-element warnings remain (only unrelated existing warnings in admin/jobs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated product gallery and swatch images to use the app's optimized image renderer for more consistent sizing, responsive behavior, and static-export compatibility.
* **Documentation**
  * Noted the image migration and CI lint follow-up in development notes.
* **Chores**
  * Applied linting directives related to image usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->