### PR TITLE
feat(web): clamp finish and collection pills in polishes table

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The web app is the most developed part of the project. Key pages:
 | `/` | `apps/web/src/app/(marketing)/page.tsx` | Marketing landing page |
 | `/dashboard` | `apps/web/src/app/(app)/dashboard/page.tsx` | Dashboard — stats cards, recent additions, finish breakdown |
 | `/admin/jobs` | `apps/web/src/app/(app)/admin/jobs/page.tsx` | Internal ingestion admin — run jobs, monitor status, inspect change metrics |
-| `/polishes` | `apps/web/src/app/(app)/polishes/page.tsx` | Collection table — search, filter by brand/finish, sortable columns |
+| `/polishes` | `apps/web/src/app/(app)/polishes/page.tsx` | Collection table — search, filter by brand/finish, sortable columns, single-line finish/collection pills with overflow popover |
 | `/polishes/new` | `apps/web/src/app/(app)/polishes/new/page.tsx` | Add polish form — color picker, star rating, voice input placeholder |
 | `/polishes/detail` | `apps/web/src/app/(app)/polishes/detail/page.tsx` | Polish detail shell (query-param based) |
 | `/polishes/search` | `apps/web/src/app/(app)/polishes/search/page.tsx` | Color wheel search — hover to preview, click to lock, similar/complementary modes |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,7 +25,7 @@ src/app/
 │   │   ├── page.tsx              → /dashboard       Stats, recent additions (computed from full paginated inventory)
 │   │   └── opengraph-image.tsx   → /dashboard OG image route
 │   └── polishes/
-│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; persists page/filter/sort state in URL query params for back-navigation restore; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
+│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; persists page/filter/sort state in URL query params for back-navigation restore; finish/collection pills stay single-line with overflow ellipsis + full-value hover/focus popover; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
 │       ├── opengraph-image.tsx   → /polishes OG image route
 │       ├── new/page.tsx          → /polishes/new     Add polish form
 │       ├── [id]/page.tsx         → /polishes/:id     Polish detail view + image preview + OKLCH profile + related shades

--- a/docs/issue-42-ui-findings-tracker.md
+++ b/docs/issue-42-ui-findings-tracker.md
@@ -20,7 +20,7 @@ This tracker captures the findings visible in that shared issue text and maps th
 | 5 | `/polishes` back navigation | medium | Preserve page/list context when returning from detail/edit | Done | Implemented in `feat/42-ui-final-slice`: list state now persists in URL query params (page, pageSize, filters, sort) |
 | 6 | `/polishes` action alignment | low | Add button alignment inconsistent with quantity controls | Verify | Current action cell is right-aligned; confirm visual consistency in latest UI |
 | 7 | `/polishes` table headers | high | Image column header missing/misaligned | Done | Fixed in #60 / #62 |
-| 8 | `/polishes` finish/collection overflow | medium | Keep single-line pills, ellipsis, hover reveal full set | Pending | Needs tooltip/popover pattern and stable row height |
+| 8 | `/polishes` finish/collection overflow | medium | Keep single-line pills, ellipsis, hover reveal full set | Done | Implemented in `feat/42-overflow-pills`: finish + collection render as single-line pills with ellipsis-on-overflow and full-value hover/focus popover |
 | 9 | `/polishes` + `/polishes/search` filters | medium | Standardize dropdown fields/options (include brand) | Pending | Requested consistency across both routes |
 | 10 | `/polishes` + `/polishes/search` collection toggle | medium | Replace dual buttons with clearer All/My Collection model | Pending | Candidate for shared reusable filter bar |
 


### PR DESCRIPTION
Summary:\n- add an overflow-aware pill cell renderer for the polishes table\n- keep Finish and Collection columns on a single line with no wrapping\n- show an ellipsis indicator when pill content overflows available column width\n- show a hover/focus popover with the full set of pills using the same badge styling\n- mark Issue #42 item #8 as done in docs/issue-42-ui-findings-tracker.md\n- update route docs in README.md and apps/web/README.md\n\nValidation:\n- npm run lint --workspace=apps/web (no new errors; existing admin/jobs warnings unchanged)\n- npm run build:web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced finish and collection pills in the polishes table with improved overflow handling—pills now display as single-line with ellipsis, and full values appear in a tooltip on hover/focus.

* **Documentation**
  * Updated project documentation to reflect the new pill display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->