### PR TITLE
fix: address follow-up review nits for polish filter helpers/tests

### DIFF
--- a/apps/web/src/lib/polish-filters.ts
+++ b/apps/web/src/lib/polish-filters.ts
@@ -1,5 +1,5 @@
 import type { Polish } from "swatchwatch-shared";
-import { undertone, type Undertone } from "./color-utils";
+import { undertone, type Undertone } from "@/lib/color-utils";
 
 export type InventoryAvailabilityFilter = "all" | "owned" | "wishlist";
 
@@ -53,6 +53,16 @@ export function matchesBrandFilter(brand: string, brandFilter: string): boolean 
   return normalizeBrand(brand) === normalizeBrand(brandFilter);
 }
 
+/**
+ * Apply list-level polish filters for search text, ownership, tone, brand, finish, and availability.
+ *
+ * Uses an internal `isOwned` check (`quantity > 0`), tone matching via `undertone(...)`,
+ * and brand matching via `matchesBrandFilter(...)` to compose the final result.
+ *
+ * @param input - Filter input containing the source `Polish[]` and active values from `ListFilterInput`
+ * (`polishes`, `search`, `includeAll`, `toneFilter`, `brandFilter`, `finishFilter`, `availabilityFilter`).
+ * @returns A filtered `Polish[]` matching all active criteria.
+ */
 export function filterPolishesForList(input: ListFilterInput): Polish[] {
   const {
     polishes,

--- a/packages/devtools/tests/documentation-validation.test.cjs
+++ b/packages/devtools/tests/documentation-validation.test.cjs
@@ -10,10 +10,11 @@ function readMarkdown(filePath) {
 
 // Helper to extract markdown headings
 function extractHeadings(content) {
+  const withoutCode = content.replace(/```[\s\S]*?```/g, '');
   const headingRegex = /^#{1,6}\s+(.+)$/gm;
   const headings = [];
   let match;
-  while ((match = headingRegex.exec(content)) !== null) {
+  while ((match = headingRegex.exec(withoutCode)) !== null) {
     const level = match[0].match(/^#+/)[0].length;
     headings.push({ level, text: match[1].trim() });
   }
@@ -104,13 +105,14 @@ test('README.md: internal documentation links are valid', () => {
   const content = readMarkdown(readmePath);
   const links = extractLinks(content);
 
-  // Check internal links (relative paths without anchors)
+  // Check internal links (relative paths, including file links with anchors)
   const internalLinks = links.filter(
-    (link) => !link.url.startsWith('http') && !link.url.startsWith('#') && !link.url.includes('#')
+    (link) => !link.url.startsWith('http') && !link.url.startsWith('#')
   );
 
   internalLinks.forEach((link) => {
-    const exists = fileExists(repoRoot, link.url);
+    const [filePath] = link.url.split('#');
+    const exists = fileExists(repoRoot, filePath);
     assert.ok(
       exists,
       `Internal link should exist: [${link.text}](${link.url})`

--- a/packages/devtools/tests/polish-filters.test.cjs
+++ b/packages/devtools/tests/polish-filters.test.cjs
@@ -4,7 +4,14 @@ const path = require("node:path");
 const os = require("node:os");
 const fs = require("node:fs/promises");
 const { pathToFileURL } = require("node:url");
-const ts = require("typescript");
+const { stripTypeScriptTypes } = require("node:module");
+
+let ts = null;
+try {
+  ts = require("typescript");
+} catch {
+  // Optional in this test harness; fallback uses node:module stripTypeScriptTypes.
+}
 
 const FILTERS_TS_PATH = path.resolve(
   __dirname,
@@ -17,6 +24,16 @@ const COLOR_UTILS_PATH = path.resolve(
 
 let importedFiltersPromise;
 
+/**
+ * Transpile a TypeScript source file (or provided source text) into a JS file.
+ *
+ * @param {object} options - Transpile options.
+ * @param {string} options.sourcePath - Absolute path of the original TypeScript source.
+ * @param {string} options.outputDir - Directory where the transpiled file is written.
+ * @param {string} options.outputFileName - Output JavaScript filename.
+ * @param {string} [options.sourceText] - Optional source text override.
+ * @returns {Promise<string>} Absolute path to the written JavaScript file.
+ */
 async function transpileToJsFile({
   sourcePath,
   outputDir,
@@ -24,19 +41,29 @@ async function transpileToJsFile({
   sourceText,
 }) {
   const text = sourceText ?? (await fs.readFile(sourcePath, "utf8"));
-  const { outputText } = ts.transpileModule(text, {
-    compilerOptions: {
-      module: ts.ModuleKind.ESNext,
-      target: ts.ScriptTarget.ES2022,
-    },
-    fileName: path.basename(sourcePath),
-  });
+  const outputText = ts?.transpileModule
+    ? ts.transpileModule(text, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: path.basename(sourcePath),
+    }).outputText
+    : stripTypeScriptTypes(text);
 
   const outputPath = path.join(outputDir, outputFileName);
   await fs.writeFile(outputPath, outputText, "utf8");
   return outputPath;
 }
 
+/**
+ * Import polish filter helpers by transpiling source TS modules into temporary JS files.
+ *
+ * Uses a cached promise to avoid repeated transpilation, writes temporary files under `os.tmpdir()`,
+ * and returns the imported module namespace (or default export for CommonJS interop).
+ *
+ * @returns {Promise<Record<string, unknown>>} Imported polish filter helper module.
+ */
 async function importFilters() {
   if (!importedFiltersPromise) {
     importedFiltersPromise = (async () => {
@@ -52,10 +79,9 @@ async function importFilters() {
       });
 
       const filtersSource = await fs.readFile(FILTERS_TS_PATH, "utf8");
-      const rewrittenFiltersSource = filtersSource.replace(
-        "./color-utils.ts",
-        "./color-utils.js"
-      );
+      const rewrittenFiltersSource = filtersSource
+        .replace('from "@/lib/color-utils"', 'from "./color-utils.js"')
+        .replace('from "./color-utils"', 'from "./color-utils.js"');
 
       const filtersJsPath = await transpileToJsFile({
         sourcePath: FILTERS_TS_PATH,
@@ -64,13 +90,20 @@ async function importFilters() {
         sourceText: rewrittenFiltersSource,
       });
 
-      return import(pathToFileURL(filtersJsPath).href);
+      const imported = await import(pathToFileURL(filtersJsPath).href);
+      return imported.default ?? imported;
     })();
   }
 
   return importedFiltersPromise;
 }
 
+/**
+ * Build a minimal `Polish`-shaped test object with optional field overrides.
+ *
+ * @param {Record<string, unknown>} [overrides={}] - Partial values to override defaults.
+ * @returns {Record<string, unknown>} Test polish object for filter scenarios.
+ */
 function createPolish(overrides = {}) {
   return {
     id: `id-${Math.random().toString(16).slice(2)}`,


### PR DESCRIPTION
## Summary
- switch `polish-filters.ts` undertone import to `@/lib/color-utils` alias
- add JSDoc for `filterPolishesForList` covering behavior and key filter semantics
- harden markdown heading/link validation in `documentation-validation.test.cjs`
- improve `polish-filters.test.cjs` helper docs and make TS->JS loading resilient in node test runner

## Validation
- `npm run test --workspace=swatchwatch-devtools` (pass)

Refs #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added advanced filtering for nail polish collections supporting search, ownership status, tone, brand, finish, and availability criteria.

* **Tests**
  * Improved documentation validation to properly handle code blocks and internal link references.
  * Enhanced test infrastructure with better TypeScript compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->