### PR TITLE
fix(web): improve dark-mode readability of dashboard summary panels

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -152,7 +152,7 @@ export default function DashboardPage() {
             />
             <CardContent className="relative z-10 flex items-center justify-between gap-4 px-6 py-6">
               <div>
-                <p className="text-[10px] font-semibold uppercase tracking-[0.35em] text-brand-purple-deep/70">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.35em] text-brand-purple-deep/80 dark:text-brand-lilac/95">
                   {card.label}
                 </p>
                 <div className="mt-1 flex items-baseline gap-1">
@@ -162,12 +162,12 @@ export default function DashboardPage() {
                     {card.value}
                   </p>
                   {card.suffix && (
-                    <span className="text-lg font-semibold text-brand-purple">
+                    <span className="text-lg font-semibold text-brand-purple dark:text-brand-pink-soft">
                       {card.suffix}
                     </span>
                   )}
                 </div>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="mt-1 text-sm text-muted-foreground dark:text-brand-pink-soft/90">
                   {card.subText}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- increase dark-mode contrast for dashboard summary panel labels, helper text, and rating suffix
- preserve existing card layout and brand gradient styling

## Testing
- npm run build --workspace=apps/web

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode appearance on the dashboard with improved color contrast and visual refinement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->