### PR TITLE
fix(web): preserve /polishes context and unify All/My scope toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The web app is the most developed part of the project. Key pages:
 | `/` | `apps/web/src/app/(marketing)/page.tsx` | Marketing landing page |
 | `/dashboard` | `apps/web/src/app/(app)/dashboard/page.tsx` | Dashboard — stats cards, recent additions, finish breakdown |
 | `/admin/jobs` | `apps/web/src/app/(app)/admin/jobs/page.tsx` | Internal ingestion admin — run jobs, monitor status, inspect change metrics |
-| `/polishes` | `apps/web/src/app/(app)/polishes/page.tsx` | Collection table — search, filter by brand/finish, sortable columns, single-line finish/collection pills with overflow popover |
+| `/polishes` | `apps/web/src/app/(app)/polishes/page.tsx` | Collection table — search/filter/sort with All/My Collection scope toggle and URL-persisted list state |
 | `/polishes/new` | `apps/web/src/app/(app)/polishes/new/page.tsx` | Add polish form — color picker, star rating, voice input placeholder |
 | `/polishes/detail` | `apps/web/src/app/(app)/polishes/detail/page.tsx` | Polish detail shell (query-param based) |
 | `/polishes/search` | `apps/web/src/app/(app)/polishes/search/page.tsx` | Color wheel search — hover to preview, click to lock, similar/complementary modes |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,11 +25,11 @@ src/app/
 │   │   ├── page.tsx              → /dashboard       Stats, recent additions (computed from full paginated inventory)
 │   │   └── opengraph-image.tsx   → /dashboard OG image route
 │   └── polishes/
-│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; persists page/filter/sort state in URL query params for back-navigation restore; standardized Brand/Tone/Finish/Availability dropdown filters; finish/collection pills stay single-line with overflow ellipsis + full-value hover/focus popover; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
+│       ├── page.tsx              → /polishes         Global polish catalog + personal inventory overlay (hydrates all API pages for client-side search/filter + sortable headers; single All/My Collection scope toggle; persists page/filter/sort state in URL query params for back-navigation restore; detail/edit flows carry `returnTo` context; swatch thumbnails open full image; admins see per-row "Recalc Hex" action)
 │       ├── opengraph-image.tsx   → /polishes OG image route
 │       ├── new/page.tsx          → /polishes/new     Add polish form
 │       ├── detail/page.tsx       → /polishes/detail  Polish detail view + image preview + OKLCH profile + related shades
-│       └── search/page.tsx       → /polishes/search  Color wheel search (two-column layout, collapsible wheel/harmonies, single full-width harmony-only selector with All mode, one-click swatch focus, focus workflow, standardized Brand/Tone/Finish/Availability dropdown filters)
+│       └── search/page.tsx       → /polishes/search  Color wheel search (two-column layout, collapsible wheel/harmonies, single full-width harmony-only selector with All mode, one-click swatch focus, focus workflow)
 ├── layout.tsx                    → Root layout (fonts, metadata — no AppShell)
 └── globals.css                   → Tailwind v4 + brand theme tokens + utility classes
 ```
@@ -148,7 +148,6 @@ cd apps/web && npx shadcn@latest add <component-name>
 | `utils.ts` | `cn()` — Tailwind class merging (shadcn standard) |
 | `constants.ts` | `FINISHES`, `finishLabel()`, `finishBadgeClassName()` — finish taxonomy and branded badge styling |
 | `color-utils.ts` | Hex↔HSL↔RGB↔OKLAB conversions, `colorDistance()`, `complementaryHex()` |
-| `polish-filters.ts` | `buildBrandOptions()`, `filterPolishesForList()`, `matchesBrandFilter()` — shared catalog/search filter helpers with normalized brand matching |
 | `api.ts` | API client helpers including polish CRUD, rapid-add capture calls, and ingestion admin methods (`listIngestionJobs`, `runIngestionJob`, `getIngestionJob`) |
 | `msal-config.ts` | `buildMsalConfig()` builder, `LOGIN_SCOPES` constant. Returns `null` if auth env is not configured |
 | `auth-token.ts` | Module-level token store: `setAccessToken()`, `getAccessToken()` |

--- a/apps/web/src/app/(app)/polishes/detail/detail-shell.tsx
+++ b/apps/web/src/app/(app)/polishes/detail/detail-shell.tsx
@@ -9,10 +9,11 @@ export default function DetailShell({ fallback }: { fallback?: ReactNode }) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const id = searchParams.get("id");
+  const returnTo = searchParams.get("returnTo");
 
   if (!id) {
     return fallback ?? <ErrorState message="Missing polish id." onRetry={() => router.push("/polishes")} />;
   }
 
-  return <PolishDetailClient id={id} />;
+  return <PolishDetailClient id={id} returnTo={returnTo} />;
 }

--- a/apps/web/src/app/(app)/polishes/new/polish-form.tsx
+++ b/apps/web/src/app/(app)/polishes/new/polish-form.tsx
@@ -44,10 +44,25 @@ const PRESET_SWATCHES = [
 
 const RATING_STARS = [1, 2, 3, 4, 5] as const;
 
+function resolveReturnTo(returnTo: string | null): string {
+  if (!returnTo) return "/polishes";
+  try {
+    const decoded = decodeURIComponent(returnTo);
+    if (decoded.startsWith("/") && !decoded.startsWith("//")) {
+      return decoded;
+    }
+  } catch {
+    // Ignore malformed values and use fallback.
+  }
+  return "/polishes";
+}
+
 export default function PolishForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const editId = searchParams.get("id");
+  const returnTo = searchParams.get("returnTo");
+  const listHref = resolveReturnTo(returnTo);
   const isEditing = Boolean(editId);
   const [form, setForm] = useState({
     brand: "",
@@ -117,13 +132,17 @@ export default function PolishForm() {
     try {
       if (isEditing && editId) {
         const updated = await updatePolish(editId, payload);
-        router.push(`/polishes/detail?id=${updated.id}`);
+        router.push(
+          `/polishes/detail?id=${updated.id}&returnTo=${encodeURIComponent(listHref)}`
+        );
       } else {
         const created = await createPolish(payload);
         if (created?.id) {
-          router.push(`/polishes/detail?id=${created.id}`);
+          router.push(
+            `/polishes/detail?id=${created.id}&returnTo=${encodeURIComponent(listHref)}`
+          );
         } else {
-          router.push("/polishes");
+          router.push(listHref);
         }
       }
     } catch (err: unknown) {
@@ -377,9 +396,11 @@ export default function PolishForm() {
                 variant="outline"
                 onClick={() => {
                   if (isEditing && editId) {
-                    router.push(`/polishes/detail?id=${editId}`);
+                    router.push(
+                      `/polishes/detail?id=${editId}&returnTo=${encodeURIComponent(listHref)}`
+                    );
                   } else {
-                    router.push("/polishes");
+                    router.push(listHref);
                   }
                 }}
               >


### PR DESCRIPTION
## Summary
- fix /polishes context restoration by carrying list-state return URL (returnTo) into detail/edit flows
- preserve page/filter/sort context when navigating list -> detail -> edit -> back
- replace dual toggle model (Favor My Collection + Include All) with a single All / My Collection scope toggle
- keep URL query persistence with legacy fallback parsing for older all=0 links
- update web docs for /polishes behavior

## Testing
- npm run build --workspace=apps/web
- commit hook test suite (workspace tests) passed

Closes #87
Closes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polishes collection list state (search, filters, sorting) now persists in URL, allowing shareable filtered views
  * Simplified collection interface with All/My Collection scope toggle
  * Detail and edit pages now intelligently return to your previous collection view

* **Documentation**
  * Updated polish page descriptions in README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->