### PR TITLE
fix(ci): package shared workspace as tarball for functions deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,27 +70,35 @@ jobs:
         run: |
           DEPLOY_DIR=packages/functions/.deploy
           rm -rf "$DEPLOY_DIR"
-          mkdir -p "$DEPLOY_DIR/_shared"
+          mkdir -p "$DEPLOY_DIR"
 
           # Copy function app artifacts
           cp packages/functions/host.json "$DEPLOY_DIR/"
           cp packages/functions/package.json "$DEPLOY_DIR/"
           cp -r packages/functions/dist "$DEPLOY_DIR/"
 
-          # Bundle the built shared package so it can be installed as a file: dep
-          cp packages/shared/package.json "$DEPLOY_DIR/_shared/"
-          cp -r packages/shared/dist "$DEPLOY_DIR/_shared/"
+          # Pack the built shared package into a tarball and install from it.
+          # Avoid file:directory deps here because npm installs those as symlinks,
+          # which can fail to resolve reliably under WEBSITE_RUN_FROM_PACKAGE.
+          SHARED_TARBALL="$(npm pack --silent --workspace=packages/shared --pack-destination "$DEPLOY_DIR" | tail -n 1)"
 
-          # Rewrite the workspace reference to a local file: path
+          # Rewrite the workspace reference to the local tarball
           node -e "
             const pkg = JSON.parse(require('fs').readFileSync('$DEPLOY_DIR/package.json', 'utf8'));
-            pkg.dependencies['swatchwatch-shared'] = 'file:_shared';
+            pkg.dependencies['swatchwatch-shared'] = 'file:${SHARED_TARBALL}';
             require('fs').writeFileSync('$DEPLOY_DIR/package.json', JSON.stringify(pkg, null, 2));
           "
 
           # Install production-only deps into the self-contained deploy dir
           cd "$DEPLOY_DIR"
           npm install --omit=dev --ignore-scripts
+
+          # Guardrail: ensure the shared package is materialized (not symlinked)
+          if [ -L "node_modules/swatchwatch-shared" ]; then
+            echo "Expected node_modules/swatchwatch-shared to be a real directory, but it is a symlink."
+            ls -la "node_modules/swatchwatch-shared"
+            exit 1
+          fi
 
       - name: Azure login (OIDC)
         uses: azure/login@v2

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -224,6 +224,7 @@ Dev deploy note:
 - Variable: `AUTH_DEV_BYPASS`
 - Secret: `AZURE_AD_B2C_CLIENT_ID`
 - Tenant source: `AZURE_AD_B2C_TENANT` variable (falls back to `NEXT_PUBLIC_B2C_TENANT`)
+- Deployment packaging installs `swatchwatch-shared` from a local `.tgz` tarball (not a `file:` directory symlink) so `WEBSITE_RUN_FROM_PACKAGE` can resolve it reliably.
 - Post-deploy smoke tests:
   - `POST /api/voice` with a JSON body should return `400` (host reachable + routing works).
   - When `AUTH_DEV_BYPASS=true`, `GET /api/polishes?pageSize=1` with `Authorization: Bearer dev:1` should return `200` (auth + DB path).


### PR DESCRIPTION
## Summary
- fix Functions deploy packaging to install swatchwatch-shared from a local .tgz tarball instead of a file: directory
- avoid symlinked node_modules/swatchwatch-shared in the deployment artifact, which can fail under WEBSITE_RUN_FROM_PACKAGE
- add a guardrail in deploy packaging to fail if node_modules/swatchwatch-shared is still a symlink
- document the packaging behavior in packages/functions/README.md

## Why
Dev smoke tests are failing with /api/voice returning 404 and the Function host indexing zero functions (/admin/functions returned []). The deployed package contained node_modules/swatchwatch-shared as a symlink entry.

## Validation
- local repo tests ran during commit hook and passed
- branch push pre-push build passed for packages/functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment packaging to use tarball approach for shared dependencies, ensuring reliable dependency resolution during deployment.

* **Documentation**
  * Added clarification to deployment notes regarding shared dependency packaging method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->