### PR TITLE
feat: release redis-backed api caching with invalidation

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -105,7 +105,7 @@ In external OpenAI mode (`CREATE_OPENAI_RESOURCES=false`), the workflow resolves
 | `openai_model_version` | `2024-07-18` | Azure OpenAI model version for the hex detector deployment |
 | `openai_deployment_capacity` | `100` | Provisioned throughput units for the OpenAI deployment (`GlobalStandard` SKU) |
 | `is_automation` | `false` | Flag for CI/CD pipelines (skips deployer Key Vault access policy) |
-| `domain_name` | `swatchwatch.app` | Root domain name for the application (used for custom domains and CORS) |
+| `domain_name` | `swatchwatch.app` | Root domain name for the application (used for custom domains and CORS; prod allows both apex and `www`) |
 | `azure_ad_b2c_tenant` | `to-be-added` | Azure AD B2C/Entra External ID tenant name applied to Function App setting `AZURE_AD_B2C_TENANT` |
 | `azure_ad_b2c_client_id` | `to-be-added` | Azure AD B2C/Entra External ID app client ID applied to Function App setting `AZURE_AD_B2C_CLIENT_ID` |
 | `auth_dev_bypass` | `false` | Controls Function App setting `AUTH_DEV_BYPASS`; keep `false` to require JWT validation |

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -60,6 +60,7 @@ In external OpenAI mode (`CREATE_OPENAI_RESOURCES=false`), the workflow resolves
 |----------|-------------------|---------|
 | Resource Group | `azurerm_resource_group.main` | Container for all resources |
 | Key Vault | `azurerm_key_vault.main` | Secure secrets storage (PG password, API keys) |
+| Key Vault Secret (Redis key) | `azurerm_key_vault_secret.redis_key` | Stores Redis access key for Function App Key Vault reference |
 | PostgreSQL Flexible Server | `azurerm_postgresql_flexible_server.main` | PostgreSQL 16 with pg_trgm + pgvector |
 | PostgreSQL Database | `azurerm_postgresql_flexible_server_database.main` | `swatchwatch` database |
 | Storage Account | `azurerm_storage_account.main` | Blob storage for images |

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -290,7 +290,7 @@ resource "azurerm_linux_function_app" "main" {
     }
 
     cors {
-      allowed_origins     = concat(local.web_app_origins, var.environment == "prod" ? [] : ["http://localhost:3000"])
+      allowed_origins     = local.function_cors_allowed_origins
       support_credentials = false
     }
   }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -317,7 +317,7 @@ resource "azurerm_linux_function_app" "main" {
     AUTH_DEV_BYPASS             = var.auth_dev_bypass ? "true" : "false"
     CORS_ALLOWED_ORIGINS        = join(",", local.function_cors_allowed_origins)
     REDIS_URL                   = "rediss://${azurerm_managed_redis.main.hostname}:10000"
-    REDIS_KEY                   = azurerm_managed_redis.main.default_database[0].primary_access_key
+    REDIS_KEY                   = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.redis_key.versionless_id})"
   }
 
   lifecycle {
@@ -375,6 +375,17 @@ resource "azurerm_managed_redis" "main" {
   default_database {
     access_keys_authentication_enabled = true
   }
+}
+
+resource "azurerm_key_vault_secret" "redis_key" {
+  name         = "redis-key"
+  value        = azurerm_managed_redis.main.default_database[0].primary_access_key
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.github_actions,
+  ]
 }
 
 # ── Azure Speech Services ──────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -3631,6 +3631,16 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
       "cpu": [
@@ -4410,6 +4420,28 @@
         "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
       "cpu": [
@@ -4420,6 +4452,402 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -6821,6 +7249,74 @@
         }
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
+      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.11.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
+      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.11.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
+      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.11.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
+      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.11.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "dev": true,
@@ -8858,6 +9354,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/code-block-writer": {
@@ -15012,6 +15517,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
+      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.11.0",
+        "@redis/client": "5.11.0",
+        "@redis/json": "5.11.0",
+        "@redis/search": "5.11.0",
+        "@redis/time-series": "5.11.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "dev": true,
@@ -17636,6 +18157,7 @@
         "applicationinsights": "^3.13.0",
         "jose": "^6.1.3",
         "pg": "^8.18.0",
+        "redis": "^5.11.0",
         "sharp": "^0.34.5",
         "swatchwatch-shared": "*"
       },

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -20,6 +20,7 @@
     "applicationinsights": "^3.13.0",
     "jose": "^6.1.3",
     "pg": "^8.18.0",
+    "redis": "^5.11.0",
     "sharp": "^0.34.5",
     "swatchwatch-shared": "*"
   },

--- a/packages/functions/src/functions/catalog.ts
+++ b/packages/functions/src/functions/catalog.ts
@@ -31,7 +31,13 @@ async function searchCatalog(request: HttpRequest, context: InvocationContext): 
   try {
     const cachedSearch = await cacheGetJson<CatalogSearchResponse>(searchCacheKey);
     if (cachedSearch) {
-      return { status: 200, jsonBody: cachedSearch };
+      return {
+        status: 200,
+        jsonBody: {
+          ...cachedSearch,
+          query: q,
+        },
+      };
     }
 
     // Search shades by name similarity + brand name similarity,

--- a/packages/functions/src/functions/polishes.ts
+++ b/packages/functions/src/functions/polishes.ts
@@ -147,12 +147,45 @@ const SORT_COLUMNS: Record<string, string> = {
 const POLISH_LIST_CACHE_TTL_SECONDS = 45;
 const POLISH_DETAIL_CACHE_TTL_SECONDS = 90;
 
-function buildPolishDetailCacheKey(userId: number, shadeId: number): string {
-  return `polishes:detail:u:${userId}:id:${shadeId}`;
+function getRequestOrigin(requestUrl: string): string {
+  try {
+    return new URL(requestUrl).origin.toLowerCase();
+  } catch {
+    return "unknown";
+  }
+}
+
+function normalizeFilterValue(value?: string | null): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function parseTagsFilter(tagsParam?: string | null): string[] {
+  if (!tagsParam) {
+    return [];
+  }
+  return tagsParam
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter((tag): tag is string => tag.length > 0);
+}
+
+function canonicalizeTagsForCache(tags: string[]): string {
+  if (tags.length === 0) {
+    return "";
+  }
+  return Array.from(new Set(tags))
+    .sort((a, b) => a.localeCompare(b))
+    .join(",");
+}
+
+function buildPolishDetailCacheKey(userId: number, shadeId: number, requestOrigin: string): string {
+  const originHash = hashCacheKey(requestOrigin.toLowerCase());
+  return `polishes:detail:u:${userId}:id:${shadeId}:o:${originHash}`;
 }
 
 function buildPolishListCacheKey(
   userId: number,
+  requestOrigin: string,
   payload: {
     search: string;
     brand: string;
@@ -166,14 +199,15 @@ function buildPolishListCacheKey(
     pageSize: number;
   }
 ): string {
+  const originHash = hashCacheKey(requestOrigin.toLowerCase());
   const hash = hashCacheKey(JSON.stringify(payload));
-  return `polishes:list:u:${userId}:h:${hash}`;
+  return `polishes:list:u:${userId}:o:${originHash}:h:${hash}`;
 }
 
 async function invalidatePolishCachesForUser(userId: number, shadeIds: number[] = []): Promise<void> {
   await Promise.all([
     cacheDeleteByPrefix(`polishes:list:u:${userId}:`),
-    ...shadeIds.map((shadeId) => cacheDelete(buildPolishDetailCacheKey(userId, shadeId))),
+    ...shadeIds.map((shadeId) => cacheDeleteByPrefix(`polishes:detail:u:${userId}:id:${shadeId}:`)),
   ]);
 }
 
@@ -263,6 +297,7 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
   context.log("GET /api/polishes");
 
   const id = request.params.id;
+  const requestOrigin = getRequestOrigin(request.url);
 
   // Single polish by shade id
   if (id) {
@@ -271,7 +306,7 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
       if (Number.isNaN(shadeId) || shadeId <= 0) {
         return { status: 400, jsonBody: { error: "Invalid polish id" } };
       }
-      const detailCacheKey = buildPolishDetailCacheKey(userId, shadeId);
+      const detailCacheKey = buildPolishDetailCacheKey(userId, shadeId, requestOrigin);
       const cachedPolish = await cacheGetJson<Record<string, unknown>>(detailCacheKey);
       if (cachedPolish) {
         return { status: 200, jsonBody: cachedPolish };
@@ -335,18 +370,24 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
     const scope = url.searchParams.get("scope");
     const availability = url.searchParams.get("availability") || url.searchParams.get("avail");
     const tagsParam = url.searchParams.get("tags");
-    const sortBy = url.searchParams.get("sortBy") || "createdAt";
+    const sortBy = url.searchParams.get("sortBy")?.trim() || "createdAt";
     const sortOrder = url.searchParams.get("sortOrder")?.toUpperCase() === "ASC" ? "ASC" : "DESC";
     const page = Math.max(1, parseInt(url.searchParams.get("page") || "1", 10));
     const pageSize = Math.min(250, Math.max(1, parseInt(url.searchParams.get("pageSize") || "50", 10)));
     const offset = (page - 1) * pageSize;
-    const listCacheKey = buildPolishListCacheKey(userId, {
-      search: search ?? "",
-      brand: brandFilter ?? "",
-      finish: normalizeFinish(finishFilter) ?? "",
-      scope: scope ?? "",
-      availability: availability ?? "",
-      tags: tagsParam ?? "",
+    const normalizedSearch = normalizeFilterValue(search);
+    const normalizedBrandFilter = normalizeFilterValue(brandFilter);
+    const normalizedFinishFilter = normalizeFinish(finishFilter) ?? "";
+    const normalizedScope = normalizeFilterValue(scope);
+    const normalizedAvailability = normalizeFilterValue(availability);
+    const parsedTags = parseTagsFilter(tagsParam);
+    const listCacheKey = buildPolishListCacheKey(userId, requestOrigin, {
+      search: normalizedSearch,
+      brand: normalizedBrandFilter,
+      finish: normalizedFinishFilter,
+      scope: normalizedScope,
+      availability: normalizedAvailability,
+      tags: canonicalizeTagsForCache(parsedTags),
       sortBy,
       sortOrder,
       page,
@@ -364,7 +405,7 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
     const params: Array<number | string | string[]> = [userId];
     let paramIndex = 2;
 
-    if (search) {
+    if (normalizedSearch) {
       conditions.push(
         `(b.name_canonical ILIKE $${paramIndex}
           OR s.shade_name_canonical ILIKE $${paramIndex}
@@ -376,20 +417,19 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
             WHERE tag ILIKE $${paramIndex}
           ))`
       );
-      params.push(`%${search}%`);
+      params.push(`%${normalizedSearch}%`);
       paramIndex++;
     }
 
-    if (brandFilter) {
+    if (normalizedBrandFilter) {
       conditions.push(`b.name_canonical = $${paramIndex}`);
-      params.push(brandFilter);
+      params.push(normalizedBrandFilter);
       paramIndex++;
     }
 
-    if (finishFilter) {
-      const normalizedFilter = normalizeFinish(finishFilter);
+    if (normalizedFinishFilter) {
       const filterValues =
-        normalizedFilter === "creme" ? ["creme", "cream"] : normalizedFilter ? [normalizedFilter] : [];
+        normalizedFinishFilter === "creme" ? ["creme", "cream"] : [normalizedFinishFilter];
       if (filterValues.length > 0) {
         conditions.push(`LOWER(s.finish) = ANY($${paramIndex}::text[])`);
         params.push(filterValues);
@@ -397,23 +437,20 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
       }
     }
 
-    if (scope === "collection") {
+    if (normalizedScope === "collection") {
       conditions.push(`COALESCE(ui.quantity, 0) > 0`);
     }
 
-    if (availability === "owned") {
+    if (normalizedAvailability === "owned") {
       conditions.push(`COALESCE(ui.quantity, 0) > 0`);
-    } else if (availability === "wishlist") {
+    } else if (normalizedAvailability === "wishlist") {
       conditions.push(`COALESCE(ui.quantity, 0) <= 0`);
     }
 
-    if (tagsParam) {
-      const tags = tagsParam.split(",").map((t) => t.trim()).filter(Boolean);
-      if (tags.length > 0) {
-        conditions.push(`ui.tags @> $${paramIndex}`);
-        params.push(tags);
-        paramIndex++;
-      }
+    if (parsedTags.length > 0) {
+      conditions.push(`ui.tags @> $${paramIndex}`);
+      params.push(parsedTags);
+      paramIndex++;
     }
 
     const sortColumn = SORT_COLUMNS[sortBy] || SORT_COLUMNS.createdAt;

--- a/packages/functions/src/lib/cache.ts
+++ b/packages/functions/src/lib/cache.ts
@@ -1,0 +1,144 @@
+import { createHash } from "crypto";
+import { createClient } from "redis";
+import { trackEvent, trackException } from "./telemetry";
+
+const redisUrl = process.env.REDIS_URL?.trim();
+const redisKey = process.env.REDIS_KEY?.trim();
+
+const isConfigured = Boolean(redisUrl && redisKey);
+
+type CacheClient = ReturnType<typeof createClient>;
+
+let client: CacheClient | null = null;
+let connectPromise: Promise<CacheClient | null> | null = null;
+
+function safeKeyPrefix(key: string): string {
+  const [prefix] = key.split(":");
+  return prefix || "unknown";
+}
+
+async function getClient(): Promise<CacheClient | null> {
+  if (!isConfigured) {
+    return null;
+  }
+
+  if (client?.isOpen) {
+    return client;
+  }
+
+  if (connectPromise) {
+    return connectPromise;
+  }
+
+  const nextClient = createClient({
+    url: redisUrl,
+    password: redisKey,
+  });
+
+  nextClient.on("error", (error) => {
+    trackException(error, { component: "redis", operation: "client.error" });
+  });
+
+  connectPromise = nextClient
+    .connect()
+    .then(() => {
+      client = nextClient;
+      trackEvent("cache.redis.connected");
+      return nextClient;
+    })
+    .catch((error) => {
+      trackException(error, { component: "redis", operation: "connect" });
+      return null;
+    })
+    .finally(() => {
+      connectPromise = null;
+    });
+
+  return connectPromise;
+}
+
+export function hashCacheKey(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 24);
+}
+
+export async function cacheGetJson<T>(key: string): Promise<T | null> {
+  const redis = await getClient();
+  if (!redis) return null;
+
+  try {
+    const raw = await redis.get(key);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    trackException(error, {
+      component: "redis",
+      operation: "get",
+      keyPrefix: safeKeyPrefix(key),
+    });
+    return null;
+  }
+}
+
+export async function cacheSetJson(
+  key: string,
+  value: unknown,
+  ttlSeconds: number
+): Promise<void> {
+  const redis = await getClient();
+  if (!redis) return;
+
+  try {
+    const serialized = JSON.stringify(value);
+    await redis.set(key, serialized, { EX: ttlSeconds });
+  } catch (error) {
+    trackException(error, {
+      component: "redis",
+      operation: "set",
+      keyPrefix: safeKeyPrefix(key),
+      ttlSeconds,
+    });
+  }
+}
+
+export async function cacheDelete(key: string): Promise<void> {
+  const redis = await getClient();
+  if (!redis) return;
+
+  try {
+    await redis.del(key);
+  } catch (error) {
+    trackException(error, {
+      component: "redis",
+      operation: "del",
+      keyPrefix: safeKeyPrefix(key),
+    });
+  }
+}
+
+export async function cacheDeleteByPrefix(prefix: string): Promise<void> {
+  const redis = await getClient();
+  if (!redis) return;
+
+  try {
+    const keys: string[] = [];
+    for await (const scanResult of redis.scanIterator({ MATCH: `${prefix}*`, COUNT: 100 })) {
+      const batch = Array.isArray(scanResult) ? scanResult : [scanResult];
+      keys.push(...batch);
+      if (keys.length >= 100) {
+        await Promise.all(keys.map((key) => redis.del(key)));
+        keys.length = 0;
+      }
+    }
+    if (keys.length > 0) {
+      await Promise.all(keys.map((key) => redis.del(key)));
+    }
+  } catch (error) {
+    trackException(error, {
+      component: "redis",
+      operation: "scan-del",
+      keyPrefix: safeKeyPrefix(prefix),
+    });
+  }
+}

--- a/packages/functions/src/lib/cache.ts
+++ b/packages/functions/src/lib/cache.ts
@@ -33,34 +33,54 @@ async function getClient(): Promise<CacheClient | null> {
   const nextClient = createClient({
     url: redisUrl,
     password: redisKey,
+    socket: {
+      connectTimeout: 5000,
+      reconnectStrategy: (retries: number) => {
+        if (retries >= 5) {
+          return false;
+        }
+        return Math.min((retries + 1) * 200, 2000);
+      },
+    },
   });
 
   nextClient.on("error", (error) => {
     trackException(error, { component: "redis", operation: "client.error" });
   });
 
-  connectPromise = nextClient
-    .connect()
-    .then(() => {
+  connectPromise = (async () => {
+    try {
+      await nextClient.connect();
       client = nextClient;
       trackEvent("cache.redis.connected");
       return nextClient;
-    })
-    .catch((error) => {
+    } catch (error) {
       trackException(error, { component: "redis", operation: "connect" });
       return null;
-    })
-    .finally(() => {
+    } finally {
       connectPromise = null;
-    });
+    }
+  })();
 
   return connectPromise;
 }
 
+/**
+ * Returns a short deterministic hash for cache key payloads.
+ *
+ * @param input - Raw string payload to hash.
+ * @returns First 24 hex chars of a SHA-256 digest.
+ */
 export function hashCacheKey(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 24);
 }
 
+/**
+ * Reads and parses a JSON value from Redis.
+ *
+ * @param key - Fully-qualified Redis key (for example `catalog:search:h:<hash>`).
+ * @returns Parsed value, or `null` when key is missing, cache is disabled, or read/parse fails.
+ */
 export async function cacheGetJson<T>(key: string): Promise<T | null> {
   const redis = await getClient();
   if (!redis) return null;
@@ -81,11 +101,23 @@ export async function cacheGetJson<T>(key: string): Promise<T | null> {
   }
 }
 
+/**
+ * Serializes a value as JSON and stores it in Redis with a TTL.
+ *
+ * @param key - Fully-qualified Redis key to upsert.
+ * @param value - JSON-serializable payload to cache.
+ * @param ttlSeconds - TTL in seconds; values `<= 0` skip writing.
+ * @returns Resolves when write is complete (or skipped). Errors are tracked and not rethrown.
+ */
 export async function cacheSetJson(
   key: string,
   value: unknown,
   ttlSeconds: number
 ): Promise<void> {
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    return;
+  }
+
   const redis = await getClient();
   if (!redis) return;
 
@@ -102,6 +134,12 @@ export async function cacheSetJson(
   }
 }
 
+/**
+ * Deletes a single Redis key.
+ *
+ * @param key - Fully-qualified Redis key to delete.
+ * @returns Resolves when deletion completes. Errors are tracked and not rethrown.
+ */
 export async function cacheDelete(key: string): Promise<void> {
   const redis = await getClient();
   if (!redis) return;
@@ -117,6 +155,12 @@ export async function cacheDelete(key: string): Promise<void> {
   }
 }
 
+/**
+ * Deletes all keys that match a prefix using Redis SCAN.
+ *
+ * @param prefix - Key prefix without wildcard (for example `polishes:list:u:42:`).
+ * @returns Resolves when scan/delete work completes. Errors are tracked and not rethrown.
+ */
 export async function cacheDeleteByPrefix(prefix: string): Promise<void> {
   const redis = await getClient();
   if (!redis) return;

--- a/packages/functions/tests/cache.unit.test.cjs
+++ b/packages/functions/tests/cache.unit.test.cjs
@@ -1,0 +1,511 @@
+const { describe, it, beforeEach, afterEach, after } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const Module = require("node:module");
+
+const cacheModulePath = path.resolve(__dirname, "../dist/lib/cache.js");
+
+const originalResolve = Module._resolveFilename;
+const originalRedisUrl = process.env.REDIS_URL;
+const originalRedisKey = process.env.REDIS_KEY;
+
+const mockModules = {};
+
+function registerMock(id, exports) {
+  mockModules[id] = exports;
+  require.cache[id] = {
+    id,
+    filename: id,
+    loaded: true,
+    exports,
+  };
+}
+
+Module._resolveFilename = function (request, parent, ...rest) {
+  for (const key of Object.keys(mockModules)) {
+    if (request === key || request.endsWith(key)) {
+      return key;
+    }
+  }
+  return originalResolve.call(this, request, parent, ...rest);
+};
+
+function makeDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function buildRedisClient(overrides = {}) {
+  const state = {
+    isOpen: false,
+    connectCalls: 0,
+    getCalls: [],
+    setCalls: [],
+    delCalls: [],
+    scanCalls: [],
+    handlers: {},
+  };
+
+  const client = {
+    get isOpen() {
+      return state.isOpen;
+    },
+    on(event, handler) {
+      state.handlers[event] = handler;
+    },
+    async connect() {
+      state.connectCalls += 1;
+      if (overrides.connect) {
+        return overrides.connect(state);
+      }
+      state.isOpen = true;
+      return undefined;
+    },
+    async get(key) {
+      state.getCalls.push(key);
+      if (overrides.get) {
+        return overrides.get(key, state);
+      }
+      return null;
+    },
+    async set(...args) {
+      state.setCalls.push(args);
+      if (overrides.set) {
+        return overrides.set(...args, state);
+      }
+      return undefined;
+    },
+    async del(key) {
+      state.delCalls.push(key);
+      if (overrides.del) {
+        return overrides.del(key, state);
+      }
+      return 1;
+    },
+    scanIterator(options) {
+      state.scanCalls.push(options);
+      if (overrides.scanIterator) {
+        return overrides.scanIterator(options, state);
+      }
+      return (async function* emptyIterator() {})();
+    },
+  };
+
+  return { client, state };
+}
+
+function loadCacheWithMocks({
+  createClientImpl,
+  telemetry,
+  redisUrl = "redis://cache.local:6379",
+  redisKey = "test-key",
+}) {
+  if (typeof redisUrl === "string") {
+    process.env.REDIS_URL = redisUrl;
+  } else {
+    delete process.env.REDIS_URL;
+  }
+
+  if (typeof redisKey === "string") {
+    process.env.REDIS_KEY = redisKey;
+  } else {
+    delete process.env.REDIS_KEY;
+  }
+
+  registerMock("redis", { createClient: createClientImpl });
+  registerMock("./telemetry", telemetry);
+
+  delete require.cache[cacheModulePath];
+  return require(cacheModulePath);
+}
+
+beforeEach(() => {
+  delete require.cache[cacheModulePath];
+});
+
+afterEach(() => {
+  delete require.cache[cacheModulePath];
+
+  if (typeof originalRedisUrl === "undefined") {
+    delete process.env.REDIS_URL;
+  } else {
+    process.env.REDIS_URL = originalRedisUrl;
+  }
+
+  if (typeof originalRedisKey === "undefined") {
+    delete process.env.REDIS_KEY;
+  } else {
+    process.env.REDIS_KEY = originalRedisKey;
+  }
+});
+
+after(() => {
+  Module._resolveFilename = originalResolve;
+  for (const id of Object.keys(mockModules)) {
+    delete require.cache[id];
+  }
+  delete require.cache[cacheModulePath];
+});
+
+describe("lib/cache", () => {
+  it("connects once, records telemetry, and reuses the open client", async () => {
+    const events = [];
+    const exceptions = [];
+    const createClientCalls = [];
+
+    const { client, state } = buildRedisClient({
+      get: async () => JSON.stringify({ ok: true }),
+    });
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: (options) => {
+        createClientCalls.push(options);
+        return client;
+      },
+      telemetry: {
+        trackEvent: (name, props) => events.push({ name, props }),
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    const first = await cache.cacheGetJson("catalog:search:h:1");
+    const second = await cache.cacheGetJson("catalog:search:h:2");
+
+    assert.deepEqual(first, { ok: true });
+    assert.deepEqual(second, { ok: true });
+    assert.equal(createClientCalls.length, 1);
+    assert.equal(state.connectCalls, 1);
+    assert.deepEqual(events.map((e) => e.name), ["cache.redis.connected"]);
+    assert.equal(exceptions.length, 0);
+    assert.equal(createClientCalls[0].socket.connectTimeout, 5000);
+    assert.equal(typeof createClientCalls[0].socket.reconnectStrategy, "function");
+  });
+
+  it("returns null and tracks exception when Redis connect fails", async () => {
+    const events = [];
+    const exceptions = [];
+    const expected = new Error("connect failed");
+
+    const { client, state } = buildRedisClient({
+      connect: async () => {
+        throw expected;
+      },
+    });
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: (name, props) => events.push({ name, props }),
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    const value = await cache.cacheGetJson("catalog:search:h:2");
+
+    assert.equal(value, null);
+    assert.equal(state.connectCalls, 1);
+    assert.equal(events.length, 0);
+    assert.equal(exceptions.length, 1);
+    assert.equal(exceptions[0].error, expected);
+    assert.deepEqual(exceptions[0].props, {
+      component: "redis",
+      operation: "connect",
+    });
+  });
+
+  it("skips Redis operations when cache environment variables are missing", async () => {
+    let createClientCalled = false;
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => {
+        createClientCalled = true;
+        return buildRedisClient().client;
+      },
+      telemetry: {
+        trackEvent: () => {},
+        trackException: () => {},
+      },
+      redisUrl: null,
+      redisKey: null,
+    });
+
+    const result = await cache.cacheGetJson("catalog:search:h:no-config");
+    await cache.cacheSetJson("catalog:search:h:no-config", { ok: true }, 10);
+    await cache.cacheDelete("catalog:search:h:no-config");
+
+    assert.equal(result, null);
+    assert.equal(createClientCalled, false);
+  });
+
+  it("shares an in-flight connect promise across concurrent requests", async () => {
+    const deferred = makeDeferred();
+    const createClientCalls = [];
+
+    const { client, state } = buildRedisClient({
+      connect: async (s) => {
+        await deferred.promise;
+        s.isOpen = true;
+      },
+      get: async () => null,
+    });
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: (options) => {
+        createClientCalls.push(options);
+        return client;
+      },
+      telemetry: {
+        trackEvent: () => {},
+        trackException: () => {},
+      },
+    });
+
+    const pendingA = cache.cacheGetJson("polishes:list:u:1:h:a");
+    const pendingB = cache.cacheGetJson("polishes:list:u:1:h:b");
+
+    await Promise.resolve();
+    assert.equal(createClientCalls.length, 1);
+    assert.equal(state.connectCalls, 1);
+
+    deferred.resolve();
+    const [resultA, resultB] = await Promise.all([pendingA, pendingB]);
+
+    assert.equal(resultA, null);
+    assert.equal(resultB, null);
+    assert.equal(state.getCalls.length, 2);
+  });
+
+  it("cacheGetJson returns null when key is missing", async () => {
+    const { client } = buildRedisClient({
+      get: async () => null,
+    });
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: () => {},
+      },
+    });
+
+    const value = await cache.cacheGetJson("catalog:search:h:missing");
+    assert.equal(value, null);
+  });
+
+  it("cacheGetJson tracks exceptions for parse/get failures", async () => {
+    const exceptions = [];
+    const parseClient = buildRedisClient({
+      get: async () => "{bad json",
+    }).client;
+
+    const cacheWithParseError = loadCacheWithMocks({
+      createClientImpl: () => parseClient,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    const parseResult = await cacheWithParseError.cacheGetJson("catalog:search:h:parse");
+    assert.equal(parseResult, null);
+    assert.equal(exceptions.length, 1);
+    assert.deepEqual(exceptions[0].props, {
+      component: "redis",
+      operation: "get",
+      keyPrefix: "catalog",
+    });
+
+    const getError = new Error("redis get failed");
+    const getClient = buildRedisClient({
+      get: async () => {
+        throw getError;
+      },
+    }).client;
+
+    const cacheWithGetError = loadCacheWithMocks({
+      createClientImpl: () => getClient,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    const getResult = await cacheWithGetError.cacheGetJson("polishes:list:u:1:h:x");
+    assert.equal(getResult, null);
+    assert.equal(exceptions.length, 2);
+    assert.equal(exceptions[1].error, getError);
+    assert.deepEqual(exceptions[1].props, {
+      component: "redis",
+      operation: "get",
+      keyPrefix: "polishes",
+    });
+  });
+
+  it("cacheSetJson serializes payload, applies EX TTL, and tracks set errors", async () => {
+    const exceptions = [];
+    const { client, state } = buildRedisClient();
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    await cache.cacheSetJson("reference:finishes", { ok: true }, 45);
+    assert.equal(state.setCalls.length, 1);
+    assert.equal(state.setCalls[0][0], "reference:finishes");
+    assert.equal(state.setCalls[0][1], JSON.stringify({ ok: true }));
+    assert.deepEqual(state.setCalls[0][2], { EX: 45 });
+
+    const setError = new Error("set failed");
+    const failingClient = buildRedisClient({
+      set: async () => {
+        throw setError;
+      },
+    }).client;
+
+    const failingCache = loadCacheWithMocks({
+      createClientImpl: () => failingClient,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    await failingCache.cacheSetJson("reference:harmonies", { ok: true }, 60);
+    assert.equal(exceptions.length, 1);
+    assert.equal(exceptions[0].error, setError);
+    assert.deepEqual(exceptions[0].props, {
+      component: "redis",
+      operation: "set",
+      keyPrefix: "reference",
+      ttlSeconds: 60,
+    });
+  });
+
+  it("cacheDelete calls del and tracks delete failures", async () => {
+    const exceptions = [];
+    const { client, state } = buildRedisClient();
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    await cache.cacheDelete("polishes:detail:u:1:id:2");
+    assert.deepEqual(state.delCalls, ["polishes:detail:u:1:id:2"]);
+
+    const deleteError = new Error("del failed");
+    const failingClient = buildRedisClient({
+      del: async () => {
+        throw deleteError;
+      },
+    }).client;
+
+    const failingCache = loadCacheWithMocks({
+      createClientImpl: () => failingClient,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    await failingCache.cacheDelete("catalog:shade:id:1");
+    assert.equal(exceptions.length, 1);
+    assert.equal(exceptions[0].error, deleteError);
+    assert.deepEqual(exceptions[0].props, {
+      component: "redis",
+      operation: "del",
+      keyPrefix: "catalog",
+    });
+  });
+
+  it("cacheDeleteByPrefix scans, deletes in batches, and removes remainder keys", async () => {
+    const exceptions = [];
+    let deletedBeforeThirdScan = false;
+
+    const firstBatch = Array.from({ length: 60 }, (_, idx) => `k:${idx}`);
+    const secondBatch = Array.from({ length: 40 }, (_, idx) => `k:${idx + 60}`);
+    const thirdBatch = Array.from({ length: 5 }, (_, idx) => `k:${idx + 100}`);
+
+    const { client, state } = buildRedisClient({
+      scanIterator: async function* (_options, s) {
+        yield firstBatch;
+        yield secondBatch;
+        deletedBeforeThirdScan = s.delCalls.length >= 100;
+        yield thirdBatch;
+      },
+    });
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    await cache.cacheDeleteByPrefix("polishes:list:u:1:");
+
+    assert.equal(state.scanCalls.length, 1);
+    assert.deepEqual(state.scanCalls[0], {
+      MATCH: "polishes:list:u:1:*",
+      COUNT: 100,
+    });
+    assert.equal(deletedBeforeThirdScan, true);
+    assert.equal(state.delCalls.length, 105);
+    assert.equal(exceptions.length, 0);
+  });
+
+  it("cacheDeleteByPrefix tracks scan/delete failures", async () => {
+    const exceptions = [];
+    const scanError = new Error("scan failed");
+
+    const { client } = buildRedisClient({
+      scanIterator: async function* () {
+        throw scanError;
+      },
+    });
+
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: (error, props) => exceptions.push({ error, props }),
+      },
+    });
+
+    await cache.cacheDeleteByPrefix("reference:");
+
+    assert.equal(exceptions.length, 1);
+    assert.equal(exceptions[0].error, scanError);
+    assert.deepEqual(exceptions[0].props, {
+      component: "redis",
+      operation: "scan-del",
+      keyPrefix: "reference",
+    });
+  });
+
+  it("cacheSetJson is a no-op when ttlSeconds <= 0", async () => {
+    const { client, state } = buildRedisClient();
+    const cache = loadCacheWithMocks({
+      createClientImpl: () => client,
+      telemetry: {
+        trackEvent: () => {},
+        trackException: () => {},
+      },
+    });
+
+    await cache.cacheSetJson("catalog:search:h:ttl0", { ok: true }, 0);
+    assert.equal(state.setCalls.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Merging dev into main to release Redis caching functionality:

- **Redis-backed API caching** with automatic invalidation
- **URL state stability** fixes for polishes page
- Other bug fixes and improvements from dev

## Key Changes

- `3eced30` feat: add redis-backed api caching with invalidation
- `c70fbc5` fix: stabilize polishes URL state and prod CORS origins

## Testing

All checks should pass on dev. Ready for production deployment after merge.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/mattmck/swatchwatch/131?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL search/filter sync with browser history for more reliable back/forward navigation.
  * Server-side Redis caching for catalog, reference, and polish endpoints to speed up reads.

* **Improvements**
  * Debounced input aligned with server queries and prevented unwanted page resets during URL-driven navigation.
  * Automatic cache invalidation on writes to keep reads fresh.
  * Expanded allowed CORS origins and refined domain handling.

* **Documentation**
  * Added caching configuration and new REDIS environment variable details.

* **Tests**
  * Added unit tests for the Redis-backed cache utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->