### PR TITLE
feat: add identity linking and admin user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Web / Mobile → Azure Functions REST API → Azure PostgreSQL Flexible Server
 Admin authorization note:
 - In production auth mode, admin access is determined by Entra token `roles` (expects `admin`).
 - The backend mirrors that role into `app_user.role` on authenticated requests.
-- External identities are linked to one local account by email via `user_external_identities`; admins can manually merge duplicates with `POST /api/admin/users/merge`.
+- External identities are linked to one local account by email via `user_external_identities`; admins can manually merge duplicates with `POST /api/admin/users/merge`. Apply the migration that creates `user_external_identities` first (`npm run migrate --workspace=packages/functions`) before relying on linkage or using `POST /api/admin/users/merge`.
 
 ### Deploy Targets
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # 💅 SwatchWatch
 
+[![CI](https://github.com/mattmck/swatchwatch/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/mattmck/swatchwatch/actions/workflows/ci.yml)
+[![Deploy Dev](https://github.com/mattmck/swatchwatch/actions/workflows/deploy-dev.yml/badge.svg?branch=dev)](https://github.com/mattmck/swatchwatch/actions/workflows/deploy-dev.yml)
+[![Deploy Prod](https://github.com/mattmck/swatchwatch/actions/workflows/deploy-prod.yml/badge.svg?branch=main)](https://github.com/mattmck/swatchwatch/actions/workflows/deploy-prod.yml)
+![Last Commit](https://img.shields.io/github/last-commit/mattmck/swatchwatch)
+![Issues](https://img.shields.io/github/issues/mattmck/swatchwatch)
+![PRs](https://img.shields.io/github/issues-pr/mattmck/swatchwatch)
+![License](https://img.shields.io/github/license/mattmck/swatchwatch)
+
 Smart nail polish collection manager with voice input, color-based search, and cross-platform support.
 
 ## Architecture
@@ -34,6 +42,7 @@ Web / Mobile → Azure Functions REST API → Azure PostgreSQL Flexible Server
 Admin authorization note:
 - In production auth mode, admin access is determined by Entra token `roles` (expects `admin`).
 - The backend mirrors that role into `app_user.role` on authenticated requests.
+- External identities are linked to one local account by email via `user_external_identities`; admins can manually merge duplicates with `POST /api/admin/users/merge`.
 
 ### Deploy Targets
 
@@ -125,7 +134,7 @@ The web app is the most developed part of the project. Key pages:
 |-------|------|-------------|
 | `/` | `apps/web/src/app/(marketing)/page.tsx` | Marketing landing page |
 | `/dashboard` | `apps/web/src/app/(app)/dashboard/page.tsx` | Dashboard — stats cards, recent additions, finish breakdown |
-| `/admin` | `apps/web/src/app/(admin)/admin/page.tsx` | Unified admin console — tabs: Configuration (finish/harmony CRUD), Job Runs (reference-admin jobs), Admin Jobs (ingestion jobs) |
+| `/admin` | `apps/web/src/app/(admin)/admin/page.tsx` | Unified admin console — tabs: Configuration (finish/harmony CRUD), Job Runs (reference-admin jobs), Admin Jobs (ingestion jobs), User Management (duplicate-account repair + merges) |
 | `/admin/reference-data` | `apps/web/src/app/(admin)/admin/reference-data/page.tsx` | Legacy redirect → `/admin?tab=configuration` |
 | `/admin/jobs` | `apps/web/src/app/(app)/admin/jobs/page.tsx` | Legacy redirect → `/admin?tab=admin-jobs` |
 | `/polishes` | `apps/web/src/app/(app)/polishes/page.tsx` | Collection table — search/filter/sort with All/My Collection scope toggle and URL-persisted list state |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -20,12 +20,13 @@ src/app/
 │   └── page.tsx                  → /           Landing page (hero, features, interactive showcase, testimonials, CTA)
 ├── (admin)/
 │   └── admin/
-│       ├── page.tsx              → /admin  Unified admin console (tabs: Configuration, Job Runs, Admin Jobs). Renders with RequireAuth + AppShell at the page level.
+│       ├── page.tsx              → /admin  Unified admin console (tabs: Configuration, Job Runs, Admin Jobs, User Management). Renders with RequireAuth + AppShell at the page level.
 │       └── reference-data/
 │           ├── page.tsx          → /admin/reference-data  Legacy redirect → `/admin?tab=configuration`
 │           └── components/
 │               ├── jobs-tab.tsx  → Job Runs tab (list `/api/reference-admin/jobs`, status/error inspection, filtering)
-│               └── config-tab.tsx → Configuration tab (finish/harmony CRUD + finish-normalization alias CRUD)
+│               ├── config-tab.tsx → Configuration tab (finish/harmony CRUD + finish-normalization alias CRUD)
+│               └── users-tab.tsx → User Management tab (`/api/admin/users` list + `/api/admin/users/merge` repair flow)
 ├── (app)/
 │   ├── layout.tsx                → App layout (AppShell sidebar wrapper)
 │   ├── admin/jobs/page.tsx       → /admin/jobs      Legacy route redirect to `/admin?tab=admin-jobs`
@@ -159,7 +160,7 @@ cd apps/web && npx shadcn@latest add <component-name>
 | `constants.ts` | `FINISHES`, `finishLabel()`, `finishBadgeClassName()` — fallback finish taxonomy and branded badge styling when reference APIs are unavailable |
 | `color-harmonies.ts` | Harmony palette generation + `getHarmonyTypeOptions()` for API-backed harmony option mapping (with fallback constants) |
 | `color-utils.ts` | Hex↔HSL↔RGB↔OKLAB↔OKLCH conversions, `colorDistance()`, harmony helpers, undertone breakdown, and `analyzeCollectionGaps()` |
-| `api.ts` | API client helpers including polish CRUD, rapid-add capture calls, ingestion admin methods (`listIngestionJobs`, `runIngestionJob`, `getIngestionJob`), reference-data admin methods (`listAdminJobs`, finish/harmony CRUD, finish-normalization CRUD), and public reference lookup methods (`listReferenceFinishTypes`, `listReferenceHarmonyTypes`) |
+| `api.ts` | API client helpers including polish CRUD, rapid-add capture calls, ingestion admin methods (`listIngestionJobs`, `runIngestionJob`, `getIngestionJob`), reference-data admin methods (`listAdminJobs`, finish/harmony CRUD, finish-normalization CRUD), user-management admin methods (`listAdminUsers`, `mergeAdminUsers`), and public reference lookup methods (`listReferenceFinishTypes`, `listReferenceHarmonyTypes`) |
 | `polish-filters.ts` | `buildBrandOptions()`, `filterPolishesForList()`, `matchesBrandFilter()` — shared catalog/search filter helpers with normalized brand matching |
 | `hooks/use-reference-data.ts` | API-backed reference data hook with in-memory + localStorage caching, resilient fallback data, and lookup helpers (`getFinishDisplayName`, `getHarmonyDisplayName`) |
 | `msal-config.ts` | `buildMsalConfig()` builder, `LOGIN_SCOPES` constant. Returns `null` if auth env is not configured |

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -12,14 +12,15 @@ import { cn } from "@/lib/utils";
 import { AdminJobsContent } from "@/app/(app)/admin/jobs/page";
 import { ConfigTab } from "./reference-data/components/config-tab";
 import { JobsTab } from "./reference-data/components/jobs-tab";
+import { UsersTab } from "./reference-data/components/users-tab";
 
 const IS_DEV_BYPASS = process.env.NEXT_PUBLIC_AUTH_DEV_BYPASS === "true";
 const HAS_B2C_CONFIG = buildMsalConfig() !== null;
 
-type AdminTab = "configuration" | "job-runs" | "admin-jobs";
+type AdminTab = "configuration" | "job-runs" | "admin-jobs" | "users";
 
 function getTabFromQuery(value: string | null): AdminTab {
-  if (value === "configuration" || value === "job-runs" || value === "admin-jobs") {
+  if (value === "configuration" || value === "job-runs" || value === "admin-jobs" || value === "users") {
     return value;
   }
   return "configuration";
@@ -92,7 +93,7 @@ function AdminContent() {
         <CardHeader>
           <CardTitle>Admin Console</CardTitle>
           <CardDescription>
-            Configuration manages reference data, Job Runs lists recent reference-data jobs, and Admin Jobs controls ingestion.
+            Configuration manages reference data, Job Runs lists recent reference-data jobs, Admin Jobs controls ingestion, and User Management repairs duplicate identities.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -125,6 +126,15 @@ function AdminContent() {
               >
                 Admin Jobs
               </TabsPrimitive.Trigger>
+              <TabsPrimitive.Trigger
+                value="users"
+                className={cn(
+                  "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium transition-all",
+                  "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+                )}
+              >
+                User Management
+              </TabsPrimitive.Trigger>
             </TabsPrimitive.List>
 
             <TabsPrimitive.Content value="configuration" className="outline-none">
@@ -137,6 +147,10 @@ function AdminContent() {
 
             <TabsPrimitive.Content value="admin-jobs" className="outline-none">
               <AdminJobsContent />
+            </TabsPrimitive.Content>
+
+            <TabsPrimitive.Content value="users" className="outline-none">
+              <UsersTab />
             </TabsPrimitive.Content>
           </TabsPrimitive.Root>
         </CardContent>

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -10,9 +10,9 @@ import { useAuth, useDevAuth, useUnconfiguredAuth } from "@/hooks/use-auth";
 import { buildMsalConfig } from "@/lib/msal-config";
 import { cn } from "@/lib/utils";
 import { AdminJobsContent } from "@/app/(app)/admin/jobs/page";
+import { UsersTab } from "@/app/(admin)/admin/reference-data/components/users-tab";
 import { ConfigTab } from "./reference-data/components/config-tab";
 import { JobsTab } from "./reference-data/components/jobs-tab";
-import { UsersTab } from "./reference-data/components/users-tab";
 
 const IS_DEV_BYPASS = process.env.NEXT_PUBLIC_AUTH_DEV_BYPASS === "true";
 const HAS_B2C_CONFIG = buildMsalConfig() !== null;

--- a/apps/web/src/app/(admin)/admin/reference-data/components/users-tab.tsx
+++ b/apps/web/src/app/(admin)/admin/reference-data/components/users-tab.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { AdminUserListItem, AdminUserMergeResponse } from "swatchwatch-shared";
+import { listAdminUsers, mergeAdminUsers } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export function UsersTab() {
+  const mountedRef = useRef(true);
+  const [users, setUsers] = useState<AdminUserListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [sourceUserId, setSourceUserId] = useState("");
+  const [targetUserId, setTargetUserId] = useState("");
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [mergePending, setMergePending] = useState(false);
+  const [lastMergeResult, setLastMergeResult] = useState<AdminUserMergeResponse | null>(null);
+
+  const loadUsers = useCallback(async () => {
+    try {
+      if (mountedRef.current) {
+        setIsLoading(true);
+        setLoadError(null);
+      }
+      const response = await listAdminUsers({ limit: 500 });
+      if (mountedRef.current) {
+        setUsers(response.users);
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        setLoadError(error instanceof Error ? error.message : "Failed to load users");
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadUsers();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [loadUsers]);
+
+  const filteredUsers = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return users;
+    return users.filter((user) => {
+      const haystack = [
+        String(user.userId),
+        user.email ?? "",
+        user.handle ?? "",
+        user.role,
+        user.externalId ?? "",
+        user.linkedExternalIds.join(" "),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(normalized);
+    });
+  }, [query, users]);
+
+  async function handleMerge() {
+    const source = Number.parseInt(sourceUserId, 10);
+    const target = Number.parseInt(targetUserId, 10);
+    if (!Number.isFinite(source) || !Number.isFinite(target) || source <= 0 || target <= 0) {
+      setMergeError("Source and target user IDs must be positive numbers.");
+      return;
+    }
+
+    try {
+      setMergePending(true);
+      setMergeError(null);
+      const response = await mergeAdminUsers({ sourceUserId: source, targetUserId: target });
+      setLastMergeResult(response);
+      setSourceUserId("");
+      setTargetUserId("");
+      await loadUsers();
+    } catch (error) {
+      setMergeError(error instanceof Error ? error.message : "Failed to merge users");
+    } finally {
+      setMergePending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Badge variant="outline">{filteredUsers.length} users</Badge>
+        <Button variant="outline" onClick={() => void loadUsers()} disabled={isLoading}>
+          {isLoading ? "Refreshing…" : "Refresh"}
+        </Button>
+      </div>
+
+      <Input
+        placeholder="Search users by id, email, handle, role, or external id"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+      />
+
+      <div className="grid gap-2 md:grid-cols-3">
+        <Input
+          placeholder="Source user ID (to delete)"
+          value={sourceUserId}
+          onChange={(event) => setSourceUserId(event.target.value)}
+        />
+        <Input
+          placeholder="Target user ID (to keep)"
+          value={targetUserId}
+          onChange={(event) => setTargetUserId(event.target.value)}
+        />
+        <Button onClick={() => void handleMerge()} disabled={mergePending}>
+          {mergePending ? "Merging…" : "Merge Users"}
+        </Button>
+      </div>
+
+      {loadError && <p className="text-sm text-destructive">{loadError}</p>}
+      {mergeError && <p className="text-sm text-destructive">{mergeError}</p>}
+
+      {lastMergeResult && (
+        <div className="rounded-md border bg-muted/20 p-3 text-sm">
+          <p className="font-medium">{lastMergeResult.message}</p>
+          <p className="text-muted-foreground">
+            Inventory moved: {lastMergeResult.mergedInventoryRows} (duplicates consolidated: {lastMergeResult.mergedInventoryDuplicateRows ?? 0})
+            {" • "}Identities moved: {lastMergeResult.mergedIdentityRows}
+            {" • "}Submissions moved: {lastMergeResult.mergedSubmissionRows}
+            {" • "}Capture sessions moved: {lastMergeResult.mergedCaptureRows}
+          </p>
+        </div>
+      )}
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Linked identities</TableHead>
+              <TableHead className="text-right">Inventory</TableHead>
+              <TableHead className="text-right">Submissions</TableHead>
+              <TableHead className="text-right">Capture</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!isLoading && filteredUsers.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-muted-foreground">
+                  No users found.
+                </TableCell>
+              </TableRow>
+            )}
+            {isLoading && (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-muted-foreground">
+                  Loading users…
+                </TableCell>
+              </TableRow>
+            )}
+            {filteredUsers.map((user) => (
+              <TableRow key={user.userId}>
+                <TableCell>
+                  <div className="font-medium">#{user.userId}</div>
+                  {user.handle && <div className="text-xs text-muted-foreground">{user.handle}</div>}
+                </TableCell>
+                <TableCell>{user.email ?? "—"}</TableCell>
+                <TableCell>
+                  <Badge variant="outline">{user.role}</Badge>
+                </TableCell>
+                <TableCell className="max-w-[320px]">
+                  <div className="truncate text-xs text-muted-foreground" title={user.linkedExternalIds.join(", ")}>
+                    {user.linkedExternalIds.length > 0 ? user.linkedExternalIds.join(", ") : "—"}
+                  </div>
+                </TableCell>
+                <TableCell className="text-right">{user.inventoryCount}</TableCell>
+                <TableCell className="text-right">{user.submissionCount}</TableCell>
+                <TableCell className="text-right">{user.captureSessionCount}</TableCell>
+                <TableCell>{formatDateTime(user.createdAt)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/reference-data/components/users-tab.tsx
+++ b/apps/web/src/app/(admin)/admin/reference-data/components/users-tab.tsx
@@ -15,12 +15,168 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+const NUMERIC_ID_PATTERN = /^\d+$/;
+
 function formatDateTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return date.toLocaleString();
 }
 
+/**
+ * Filter admin users by free-text query across key identity fields.
+ *
+ * @param users Full user list returned from the admin API.
+ * @param query Free-text query entered in the search input.
+ * @returns Filtered subset preserving original order.
+ */
+export function filterUsersByQuery(users: AdminUserListItem[], query: string): AdminUserListItem[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return users;
+  return users.filter((user) => {
+    const haystack = [
+      String(user.userId),
+      user.email ?? "",
+      user.handle ?? "",
+      user.role,
+      user.externalId ?? "",
+      user.linkedExternalIds.join(" "),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(normalized);
+  });
+}
+
+/**
+ * Parse and validate source/target user IDs for account merges.
+ *
+ * @param sourceRaw Raw source ID input value.
+ * @param targetRaw Raw target ID input value.
+ * @returns Parsed IDs or a user-facing validation error message.
+ */
+function parseMergeIds(
+  sourceRaw: string,
+  targetRaw: string
+): { source: number; target: number } | { error: string } {
+  const sourceValue = sourceRaw.trim();
+  const targetValue = targetRaw.trim();
+
+  if (!NUMERIC_ID_PATTERN.test(sourceValue) || !NUMERIC_ID_PATTERN.test(targetValue)) {
+    return { error: "Source and target user IDs must be numeric values." };
+  }
+
+  const source = Number.parseInt(sourceValue, 10);
+  const target = Number.parseInt(targetValue, 10);
+
+  if (source <= 0 || target <= 0) {
+    return { error: "Source and target user IDs must be positive numbers." };
+  }
+
+  if (source === target) {
+    return { error: "Source and target user IDs must be different." };
+  }
+
+  return { source, target };
+}
+
+/**
+ * Fetch users and update the component state holders.
+ *
+ * @param params.listUsers API request function.
+ * @param params.isMounted Guard to avoid state updates after unmount.
+ * @param params.setIsLoading Setter for loading state.
+ * @param params.setLoadError Setter for load error message.
+ * @param params.setUsers Setter for users collection.
+ */
+export async function loadUsersState(params: {
+  listUsers: typeof listAdminUsers;
+  isMounted: () => boolean;
+  setIsLoading: (loading: boolean) => void;
+  setLoadError: (message: string | null) => void;
+  setUsers: (users: AdminUserListItem[]) => void;
+}): Promise<void> {
+  const { listUsers: listUsersFn, isMounted, setIsLoading, setLoadError, setUsers } = params;
+
+  try {
+    if (isMounted()) {
+      setIsLoading(true);
+      setLoadError(null);
+    }
+    const response = await listUsersFn({ limit: 500 });
+    if (isMounted()) {
+      setUsers(response.users);
+    }
+  } catch (error) {
+    if (isMounted()) {
+      setLoadError(error instanceof Error ? error.message : "Failed to load users");
+    }
+  } finally {
+    if (isMounted()) {
+      setIsLoading(false);
+    }
+  }
+}
+
+/**
+ * Validate, confirm, and execute an admin merge operation.
+ *
+ * @param params.sourceUserId Raw source ID input.
+ * @param params.targetUserId Raw target ID input.
+ * @param params.confirm Confirmation gate callback (e.g. window.confirm).
+ * @param params.mergeUsers API call to execute merge.
+ * @param params.refreshUsers Callback to refresh the users table.
+ * @param params.setMergeError Setter for merge error state.
+ * @param params.setMergePending Setter for in-flight merge state.
+ * @param params.setLastMergeResult Setter for latest merge result.
+ * @param params.setSourceUserId Setter for source input field.
+ * @param params.setTargetUserId Setter for target input field.
+ */
+export async function handleMergeAction(params: {
+  sourceUserId: string;
+  targetUserId: string;
+  confirm: () => boolean;
+  mergeUsers: typeof mergeAdminUsers;
+  refreshUsers: () => Promise<void>;
+  setMergeError: (message: string | null) => void;
+  setMergePending: (pending: boolean) => void;
+  setLastMergeResult: (result: AdminUserMergeResponse | null) => void;
+  setSourceUserId: (value: string) => void;
+  setTargetUserId: (value: string) => void;
+}): Promise<void> {
+  const parsed = parseMergeIds(params.sourceUserId, params.targetUserId);
+  if ("error" in parsed) {
+    params.setMergeError(parsed.error);
+    return;
+  }
+
+  if (!params.confirm()) {
+    return;
+  }
+
+  try {
+    params.setMergePending(true);
+    params.setMergeError(null);
+    const response = await params.mergeUsers({
+      sourceUserId: parsed.source,
+      targetUserId: parsed.target,
+    });
+    params.setLastMergeResult(response);
+    params.setSourceUserId("");
+    params.setTargetUserId("");
+    await params.refreshUsers();
+  } catch (error) {
+    params.setMergeError(error instanceof Error ? error.message : "Failed to merge users");
+  } finally {
+    params.setMergePending(false);
+  }
+}
+
+/**
+ * Admin UI for user account management and duplicate-account merges.
+ *
+ * @returns A tab panel with user search, merge controls, and merge status feedback.
+ */
 export function UsersTab() {
   const mountedRef = useRef(true);
   const [users, setUsers] = useState<AdminUserListItem[]>([]);
@@ -33,25 +189,17 @@ export function UsersTab() {
   const [mergePending, setMergePending] = useState(false);
   const [lastMergeResult, setLastMergeResult] = useState<AdminUserMergeResponse | null>(null);
 
+  /**
+   * Load users from the admin API and synchronize loading/error state.
+   */
   const loadUsers = useCallback(async () => {
-    try {
-      if (mountedRef.current) {
-        setIsLoading(true);
-        setLoadError(null);
-      }
-      const response = await listAdminUsers({ limit: 500 });
-      if (mountedRef.current) {
-        setUsers(response.users);
-      }
-    } catch (error) {
-      if (mountedRef.current) {
-        setLoadError(error instanceof Error ? error.message : "Failed to load users");
-      }
-    } finally {
-      if (mountedRef.current) {
-        setIsLoading(false);
-      }
-    }
+    await loadUsersState({
+      listUsers: listAdminUsers,
+      isMounted: () => mountedRef.current,
+      setIsLoading,
+      setLoadError,
+      setUsers,
+    });
   }, []);
 
   useEffect(() => {
@@ -62,51 +210,35 @@ export function UsersTab() {
     };
   }, [loadUsers]);
 
-  const filteredUsers = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return users;
-    return users.filter((user) => {
-      const haystack = [
-        String(user.userId),
-        user.email ?? "",
-        user.handle ?? "",
-        user.role,
-        user.externalId ?? "",
-        user.linkedExternalIds.join(" "),
-      ]
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(normalized);
-    });
-  }, [query, users]);
+  /**
+   * Memoized filtered users derived from the active query.
+   */
+  const filteredUsersMemo = useMemo(() => filterUsersByQuery(users, query), [query, users]);
 
+  /**
+   * Validate and run a user merge after explicit admin confirmation.
+   */
   async function handleMerge() {
-    const source = Number.parseInt(sourceUserId, 10);
-    const target = Number.parseInt(targetUserId, 10);
-    if (!Number.isFinite(source) || !Number.isFinite(target) || source <= 0 || target <= 0) {
-      setMergeError("Source and target user IDs must be positive numbers.");
-      return;
-    }
-
-    try {
-      setMergePending(true);
-      setMergeError(null);
-      const response = await mergeAdminUsers({ sourceUserId: source, targetUserId: target });
-      setLastMergeResult(response);
-      setSourceUserId("");
-      setTargetUserId("");
-      await loadUsers();
-    } catch (error) {
-      setMergeError(error instanceof Error ? error.message : "Failed to merge users");
-    } finally {
-      setMergePending(false);
-    }
+    await handleMergeAction({
+      sourceUserId,
+      targetUserId,
+      confirm: () => window.confirm(
+        `Merge user ${sourceUserId.trim() || "?"} into ${targetUserId.trim() || "?"}? This cannot be undone.`
+      ),
+      mergeUsers: mergeAdminUsers,
+      refreshUsers: loadUsers,
+      setMergeError,
+      setMergePending,
+      setLastMergeResult,
+      setSourceUserId,
+      setTargetUserId,
+    });
   }
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <Badge variant="outline">{filteredUsers.length} users</Badge>
+        <Badge variant="outline">{filteredUsersMemo.length} users</Badge>
         <Button variant="outline" onClick={() => void loadUsers()} disabled={isLoading}>
           {isLoading ? "Refreshing…" : "Refresh"}
         </Button>
@@ -164,7 +296,7 @@ export function UsersTab() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {!isLoading && filteredUsers.length === 0 && (
+            {!isLoading && filteredUsersMemo.length === 0 && (
               <TableRow>
                 <TableCell colSpan={8} className="text-center text-muted-foreground">
                   No users found.
@@ -178,7 +310,7 @@ export function UsersTab() {
                 </TableCell>
               </TableRow>
             )}
-            {filteredUsers.map((user) => (
+            {filteredUsersMemo.map((user) => (
               <TableRow key={user.userId}>
                 <TableCell>
                   <div className="font-medium">#{user.userId}</div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,6 +12,9 @@ import type {
   CaptureStartResponse,
   CaptureStatusResponse,
   AdminJobsListResponse,
+  AdminUserListResponse,
+  AdminUserMergeRequest,
+  AdminUserMergeResponse,
   Polish,
   PolishCreateRequest,
   PolishUpdateRequest,
@@ -622,4 +625,29 @@ export async function deleteFinishNormalization(
     }
   );
   return handleResponse<{ success?: boolean; message?: string }>(response);
+}
+
+/** List users for admin account-repair workflows (`GET /api/admin/users`). */
+export async function listAdminUsers(params?: {
+  limit?: number;
+}): Promise<AdminUserListResponse> {
+  const searchParams = new URLSearchParams();
+  if (typeof params?.limit === "number") searchParams.set("limit", String(params.limit));
+  const qs = searchParams.toString();
+  const response = await fetch(`${API_BASE_URL}/admin/users${qs ? `?${qs}` : ""}`, {
+    headers: await getAuthHeaders({ admin: true }),
+  });
+  return handleResponse<AdminUserListResponse>(response);
+}
+
+/** Merge one duplicate user into another (`POST /api/admin/users/merge`). */
+export async function mergeAdminUsers(
+  data: AdminUserMergeRequest
+): Promise<AdminUserMergeResponse> {
+  const response = await fetch(`${API_BASE_URL}/admin/users/merge`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...await getAuthHeaders({ admin: true }) },
+    body: JSON.stringify(data),
+  });
+  return handleResponse<AdminUserMergeResponse>(response);
 }

--- a/apps/web/src/lib/users-tab.test.ts
+++ b/apps/web/src/lib/users-tab.test.ts
@@ -1,0 +1,252 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { AdminUserListItem, AdminUserMergeResponse } from "swatchwatch-shared";
+import {
+  filterUsersByQuery,
+  handleMergeAction,
+  loadUsersState,
+} from "../app/(admin)/admin/reference-data/components/users-tab";
+
+function buildUser(overrides: Partial<AdminUserListItem> = {}): AdminUserListItem {
+  return {
+    userId: 1,
+    role: "user",
+    linkedExternalIds: ["oid-1"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    inventoryCount: 0,
+    submissionCount: 0,
+    captureSessionCount: 0,
+    ...overrides,
+  };
+}
+
+describe("UsersTab helpers", () => {
+  it("loadUsersState sets loading/error/users on success", async () => {
+    const loadingStates: boolean[] = [];
+    const errorStates: Array<string | null> = [];
+    let users: AdminUserListItem[] = [];
+
+    await loadUsersState({
+      listUsers: async () => ({ users: [buildUser({ userId: 42, email: "a@test.dev" })], total: 1 }),
+      isMounted: () => true,
+      setIsLoading: (loading) => loadingStates.push(loading),
+      setLoadError: (message) => errorStates.push(message),
+      setUsers: (nextUsers) => {
+        users = nextUsers;
+      },
+    });
+
+    assert.deepEqual(loadingStates, [true, false]);
+    assert.deepEqual(errorStates, [null]);
+    assert.equal(users.length, 1);
+    assert.equal(users[0].userId, 42);
+  });
+
+  it("loadUsersState sets loadError on failure", async () => {
+    const loadingStates: boolean[] = [];
+    const errorStates: Array<string | null> = [];
+
+    await loadUsersState({
+      listUsers: async () => {
+        throw new Error("boom");
+      },
+      isMounted: () => true,
+      setIsLoading: (loading) => loadingStates.push(loading),
+      setLoadError: (message) => errorStates.push(message),
+      setUsers: () => {},
+    });
+
+    assert.deepEqual(loadingStates, [true, false]);
+    assert.deepEqual(errorStates, [null, "boom"]);
+  });
+
+  it("filterUsersByQuery returns all users when query is empty", () => {
+    const users = [
+      buildUser({ userId: 1, email: "one@test.dev" }),
+      buildUser({ userId: 2, email: "two@test.dev" }),
+    ];
+
+    const result = filterUsersByQuery(users, "   ");
+    assert.equal(result, users);
+  });
+
+  it("filterUsersByQuery matches by email/ids/linked identities", () => {
+    const users = [
+      buildUser({ userId: 1, email: "one@test.dev", linkedExternalIds: ["abc-def"] }),
+      buildUser({ userId: 2, email: "two@test.dev", linkedExternalIds: ["xyz-ghi"] }),
+    ];
+
+    assert.deepEqual(filterUsersByQuery(users, "two@test.dev").map((u) => u.userId), [2]);
+    assert.deepEqual(filterUsersByQuery(users, "abc-def").map((u) => u.userId), [1]);
+    assert.deepEqual(filterUsersByQuery(users, "2").map((u) => u.userId), [2]);
+  });
+
+  it("handleMergeAction rejects non-numeric IDs", async () => {
+    let mergeError: string | null = null;
+    let mergeCalled = false;
+
+    await handleMergeAction({
+      sourceUserId: "12abc",
+      targetUserId: "99",
+      confirm: () => true,
+      mergeUsers: async () => {
+        mergeCalled = true;
+        throw new Error("should not run");
+      },
+      refreshUsers: async () => {},
+      setMergeError: (message) => {
+        mergeError = message;
+      },
+      setMergePending: () => {},
+      setLastMergeResult: () => {},
+      setSourceUserId: () => {},
+      setTargetUserId: () => {},
+    });
+
+    assert.equal(mergeError, "Source and target user IDs must be numeric values.");
+    assert.equal(mergeCalled, false);
+  });
+
+  it("handleMergeAction rejects non-positive and identical IDs", async () => {
+    const errors: string[] = [];
+
+    await handleMergeAction({
+      sourceUserId: "0",
+      targetUserId: "4",
+      confirm: () => true,
+      mergeUsers: async () => {
+        throw new Error("should not run");
+      },
+      refreshUsers: async () => {},
+      setMergeError: (message) => {
+        if (message) errors.push(message);
+      },
+      setMergePending: () => {},
+      setLastMergeResult: () => {},
+      setSourceUserId: () => {},
+      setTargetUserId: () => {},
+    });
+
+    await handleMergeAction({
+      sourceUserId: "4",
+      targetUserId: "4",
+      confirm: () => true,
+      mergeUsers: async () => {
+        throw new Error("should not run");
+      },
+      refreshUsers: async () => {},
+      setMergeError: (message) => {
+        if (message) errors.push(message);
+      },
+      setMergePending: () => {},
+      setLastMergeResult: () => {},
+      setSourceUserId: () => {},
+      setTargetUserId: () => {},
+    });
+
+    assert.deepEqual(errors, [
+      "Source and target user IDs must be positive numbers.",
+      "Source and target user IDs must be different.",
+    ]);
+  });
+
+  it("handleMergeAction success clears inputs, sets result, and refreshes users", async () => {
+    const pendingStates: boolean[] = [];
+    const clearedSources: string[] = [];
+    const clearedTargets: string[] = [];
+    const responses: AdminUserMergeResponse[] = [];
+    let refreshCount = 0;
+
+    await handleMergeAction({
+      sourceUserId: "5",
+      targetUserId: "9",
+      confirm: () => true,
+      mergeUsers: async ({ sourceUserId, targetUserId }) => ({
+        merged: true,
+        sourceUserId,
+        targetUserId,
+        mergedByUserId: 2,
+        mergedInventoryRows: 1,
+        mergedIdentityRows: 2,
+        mergedSubmissionRows: 0,
+        mergedCaptureRows: 0,
+        mergedCaptureAnswerRows: 0,
+        mergedClickEventRows: 0,
+        message: "Merged user 5 into 9",
+      }),
+      refreshUsers: async () => {
+        refreshCount += 1;
+      },
+      setMergeError: () => {},
+      setMergePending: (pending) => pendingStates.push(pending),
+      setLastMergeResult: (result) => {
+        if (result) responses.push(result);
+      },
+      setSourceUserId: (value) => clearedSources.push(value),
+      setTargetUserId: (value) => clearedTargets.push(value),
+    });
+
+    assert.deepEqual(pendingStates, [true, false]);
+    assert.equal(refreshCount, 1);
+    assert.equal(responses.length, 1);
+    assert.equal(responses[0].sourceUserId, 5);
+    assert.equal(responses[0].targetUserId, 9);
+    assert.deepEqual(clearedSources, [""]);
+    assert.deepEqual(clearedTargets, [""]);
+  });
+
+  it("handleMergeAction stops when confirmation is cancelled", async () => {
+    let mergeCalled = false;
+    const pendingStates: boolean[] = [];
+
+    await handleMergeAction({
+      sourceUserId: "5",
+      targetUserId: "9",
+      confirm: () => false,
+      mergeUsers: async () => {
+        mergeCalled = true;
+        throw new Error("should not run");
+      },
+      refreshUsers: async () => {},
+      setMergeError: () => {},
+      setMergePending: (pending) => pendingStates.push(pending),
+      setLastMergeResult: () => {},
+      setSourceUserId: () => {},
+      setTargetUserId: () => {},
+    });
+
+    assert.equal(mergeCalled, false);
+    assert.deepEqual(pendingStates, []);
+  });
+
+  it("handleMergeAction sets mergeError on merge failure and keeps inputs", async () => {
+    const pendingStates: boolean[] = [];
+    const errors: Array<string | null> = [];
+    let sourceSetCount = 0;
+    let targetSetCount = 0;
+
+    await handleMergeAction({
+      sourceUserId: "5",
+      targetUserId: "9",
+      confirm: () => true,
+      mergeUsers: async () => {
+        throw new Error("merge failed");
+      },
+      refreshUsers: async () => {},
+      setMergeError: (message) => errors.push(message),
+      setMergePending: (pending) => pendingStates.push(pending),
+      setLastMergeResult: () => {},
+      setSourceUserId: () => {
+        sourceSetCount += 1;
+      },
+      setTargetUserId: () => {
+        targetSetCount += 1;
+      },
+    });
+
+    assert.deepEqual(pendingStates, [true, false]);
+    assert.deepEqual(errors, [null, "merge failed"]);
+    assert.equal(sourceSetCount, 0);
+    assert.equal(targetSetCount, 0);
+  });
+});

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -221,6 +221,14 @@ CREATE TABLE user_external_identities (
 CREATE INDEX idx_user_external_identities_user_id
   ON user_external_identities(user_id);
 
+CREATE TABLE app_settings (
+  setting_key TEXT PRIMARY KEY,
+  setting_value JSONB NOT NULL,
+  description TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by INTEGER REFERENCES app_user(user_id) ON DELETE SET NULL
+);
+
 CREATE TABLE finish_type (
   finish_type_id SMALLSERIAL PRIMARY KEY,
   name TEXT NOT NULL UNIQUE,

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -202,10 +202,24 @@ CREATE TABLE match_decision (
 CREATE TABLE app_user (
   user_id BIGSERIAL PRIMARY KEY,
   handle TEXT UNIQUE,
+  external_id TEXT UNIQUE,
+  email TEXT,
   role TEXT NOT NULL DEFAULT 'user',
   CONSTRAINT app_user_role_check CHECK (role IN ('user', 'admin')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+CREATE TABLE user_external_identities (
+  user_external_identity_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES app_user(user_id) ON DELETE CASCADE,
+  external_id TEXT NOT NULL UNIQUE,
+  email TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_external_identities_user_id
+  ON user_external_identities(user_id);
 
 CREATE TABLE finish_type (
   finish_type_id SMALLSERIAL PRIMARY KEY,

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -60,6 +60,8 @@ Requires **Azure Functions Core Tools v4** (`npm i -g azure-functions-core-tools
 | `POST` | `/api/reference-admin/finish-normalizations` | `adminFinishNormalizationsCollectionHandler` | `admin-reference.ts` | ✅ Working (admin-only) |
 | `PUT` | `/api/reference-admin/finish-normalizations/{id}` | `adminFinishNormalizationsItemHandler` | `admin-reference.ts` | ✅ Working (admin-only) |
 | `DELETE` | `/api/reference-admin/finish-normalizations/{id}` | `adminFinishNormalizationsItemHandler` | `admin-reference.ts` | ✅ Working (admin-only) |
+| `GET` | `/api/admin/users` | `listUsers` | `admin-users.ts` | ✅ Working (admin-only) |
+| `POST` | `/api/admin/users/merge` | `mergeUsers` | `admin-users.ts` | ✅ Working (admin-only) |
 | `POST` | `/api/voice` | `processVoiceInput` | `voice.ts` | ⬜ Stub |
 | `GET` | `/api/images/{id}` | `images` | `images.ts` | ✅ Working |
 
@@ -78,6 +80,8 @@ Reference endpoints:
 - Admin CRUD endpoints under `/api/reference-admin/finishes` and `/api/reference-admin/harmonies` manage reference data and update audit columns (`updated_at`, `updated_by_user_id`) on writes.
 - Admin CRUD endpoints under `/api/reference-admin/finish-normalizations` manage aliases and misspellings used to normalize AI/vendor finish strings into canonical `finish_type.name` values.
 - `GET /api/reference-admin/jobs` lists recent ingestion jobs with pagination (`page`, `pageSize`) and optional `status` filter (`queued|running|succeeded|failed|cancelled`), joined with `data_source` for source metadata.
+- `GET /api/admin/users` lists users with linked identities plus quick counts (inventory, submissions, capture sessions) for account-repair workflows.
+- `POST /api/admin/users/merge` manually merges one local user account into another (inventory, capture sessions, submissions, click events, and linked external identities), intended for repairing duplicate accounts created before identity linking was enabled.
 - Public reference reads and catalog lookups also use Redis read-through caching when configured; admin reference writes clear those cache entries.
 
 Adding a new reference category (example: `texture_type`):
@@ -174,6 +178,7 @@ npm run migrate:create -- my-migration-name   # Create a new migration file
 | `016_add_shade_detected_finishes.sql` | Adds detected_finishes array column to shade for AI-extracted finish tags |
 | `017_add_admin_support.sql` | Adds `finish_type` audit columns and creates/seeds `harmony_type` for admin-managed reference data |
 | `018_add_finish_normalizations.sql` | Adds editable `finish_normalization` mappings (source alias → canonical finish name) for AI/vendor finish parsing |
+| `019_add_user_external_identities.sql` | Adds `user_external_identities` and backfills existing `app_user.external_id` values to support multi-provider identity linking |
 
 node-pg-migrate tracks applied migrations in a `pgmigrations` table. `DATABASE_URL` is the preferred connection method; it also falls back to individual `PG*` env vars (`PGHOST`, `PGPORT`, etc.).
 
@@ -232,7 +237,8 @@ Key variables:
 JWT validation note:
 - In production mode (`AUTH_DEV_BYPASS=false`), auth discovery first tries Entra External ID (`ciamlogin.com`) metadata for `AZURE_AD_B2C_TENANT`, then falls back to legacy Azure AD B2C (`b2clogin.com`) metadata.
 - Accepted token audiences are `AZURE_AD_B2C_CLIENT_ID` and `api://AZURE_AD_B2C_CLIENT_ID` to support exposed-API scopes like `access_as_user`.
-- User records are still upserted in `app_user`; `role` is synchronized from Entra token roles on each authenticated request.
+- Auth links identities by `external_id` first, then by email (`one app_user per email`) using `user_external_identities`.
+- `role` is synchronized from Entra token roles on each authenticated request.
 
 Dev deploy note:
 `deploy-dev.yml` configures Function App auth settings from GitHub `dev` environment values on each deploy.

--- a/packages/functions/migrations/019_add_user_external_identities.sql
+++ b/packages/functions/migrations/019_add_user_external_identities.sql
@@ -1,0 +1,39 @@
+-- Up Migration
+
+-- 019_add_user_external_identities.sql
+-- Supports one local app_user per email with multiple linked external identities.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_external_identities (
+  user_external_identity_id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES app_user(user_id) ON DELETE CASCADE,
+  external_id TEXT NOT NULL UNIQUE,
+  email TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_external_identities_user_id
+  ON user_external_identities(user_id);
+
+-- Backfill existing app_user.external_id values so auth can transition without downtime.
+INSERT INTO user_external_identities (user_id, external_id, email)
+SELECT user_id, external_id, email
+FROM app_user
+WHERE external_id IS NOT NULL
+ON CONFLICT (external_id) DO UPDATE
+SET
+  user_id = EXCLUDED.user_id,
+  email = COALESCE(EXCLUDED.email, user_external_identities.email),
+  last_seen_at = now();
+
+COMMIT;
+
+-- Down Migration
+
+BEGIN;
+
+DROP TABLE IF EXISTS user_external_identities;
+
+COMMIT;

--- a/packages/functions/migrations/020_add_app_user_email_unique.sql
+++ b/packages/functions/migrations/020_add_app_user_email_unique.sql
@@ -1,0 +1,57 @@
+-- Up Migration
+
+-- 020_add_app_user_email_unique.sql
+-- Adds a unique constraint on lower(email) in app_user to prevent duplicate accounts
+-- for the same email address.  Deduplicates any existing rows first, keeping the
+-- oldest (lowest user_id) per normalized email and re-homing their external identities
+-- to the surviving user before deleting the extras.
+
+BEGIN;
+
+-- Step 1: Re-home user_external_identities rows from duplicate users to the
+--         surviving (oldest) user before the duplicates are deleted.
+UPDATE user_external_identities uei
+SET user_id = sub.keep_id
+FROM (
+  SELECT
+    MIN(user_id)                          AS keep_id,
+    ARRAY_AGG(user_id ORDER BY user_id)   AS all_ids
+  FROM app_user
+  WHERE email IS NOT NULL
+  GROUP BY lower(email)
+  HAVING COUNT(*) > 1
+) sub
+WHERE uei.user_id = ANY(sub.all_ids)
+  AND uei.user_id <> sub.keep_id;
+
+-- Step 2: Delete duplicate app_user rows, keeping the oldest (lowest user_id)
+--         per normalized email.  ON DELETE CASCADE on child tables removes any
+--         remaining child rows automatically.
+DELETE FROM app_user
+WHERE user_id IN (
+  SELECT user_id
+  FROM (
+    SELECT
+      user_id,
+      ROW_NUMBER() OVER (PARTITION BY lower(email) ORDER BY user_id) AS rn
+    FROM app_user
+    WHERE email IS NOT NULL
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Step 3: Add the unique index.  NULLs are excluded so that users without a
+--         known email address are still permitted.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_app_user_email_lower
+  ON app_user (lower(email))
+  WHERE email IS NOT NULL;
+
+COMMIT;
+
+-- Down Migration
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_app_user_email_lower;
+
+COMMIT;

--- a/packages/functions/migrations/020_fix_app_settings_updated_by_fk.sql
+++ b/packages/functions/migrations/020_fix_app_settings_updated_by_fk.sql
@@ -1,0 +1,18 @@
+-- Fix app_settings.updated_by FK to use ON DELETE SET NULL
+-- Migration 010 created this column without ON DELETE behaviour, which defaults to
+-- RESTRICT and causes a FK violation when deleting an app_user row (e.g. during a
+-- user-merge operation).  Re-create the constraint with ON DELETE SET NULL so that
+-- deleting a user automatically nulls the reference instead of blocking the delete.
+
+BEGIN;
+
+ALTER TABLE app_settings
+  DROP CONSTRAINT IF EXISTS app_settings_updated_by_fkey;
+
+ALTER TABLE app_settings
+  ADD CONSTRAINT app_settings_updated_by_fkey
+  FOREIGN KEY (updated_by)
+  REFERENCES app_user(user_id)
+  ON DELETE SET NULL;
+
+COMMIT;

--- a/packages/functions/src/functions/admin-users.ts
+++ b/packages/functions/src/functions/admin-users.ts
@@ -99,6 +99,22 @@ async function mergeUsers(
         [sourceUserId, targetUserId]
       );
 
+      // Migrate inventory_event rows from source duplicate items to target items
+      // before deleting the source rows, so cascade-delete does not erase history.
+      await client.query(
+        `UPDATE inventory_event ie
+         SET inventory_item_id = target.inventory_item_id
+         FROM user_inventory_item source
+         JOIN user_inventory_item target
+           ON target.user_id = $2
+          AND target.shade_id IS NOT NULL
+          AND target.shade_id = source.shade_id
+         WHERE source.user_id = $1
+           AND source.shade_id IS NOT NULL
+           AND ie.inventory_item_id = source.inventory_item_id`,
+        [sourceUserId, targetUserId]
+      );
+
       await client.query(
         `DELETE FROM user_inventory_item source
          USING user_inventory_item target

--- a/packages/functions/src/functions/admin-users.ts
+++ b/packages/functions/src/functions/admin-users.ts
@@ -1,0 +1,338 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import type {
+  AdminUserListItem,
+  AdminUserListResponse,
+  AdminUserMergeRequest,
+  AdminUserMergeResponse,
+} from "swatchwatch-shared";
+import { withAdmin } from "../lib/auth";
+import { query, transaction } from "../lib/db";
+import { withCors } from "../lib/http";
+
+function parsePositiveInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+async function mergeUsers(
+  request: HttpRequest,
+  context: InvocationContext,
+  adminUserId: number
+): Promise<HttpResponseInit> {
+  context.log("POST /api/admin/users/merge");
+
+  let body: Partial<AdminUserMergeRequest>;
+  try {
+    body = (await request.json()) as Partial<AdminUserMergeRequest>;
+  } catch {
+    return { status: 400, jsonBody: { error: "Request body must be valid JSON" } };
+  }
+
+  const sourceUserId = parsePositiveInteger(body.sourceUserId);
+  const targetUserId = parsePositiveInteger(body.targetUserId);
+  if (!sourceUserId || !targetUserId) {
+    return {
+      status: 400,
+      jsonBody: { error: "sourceUserId and targetUserId are required positive integers" },
+    };
+  }
+
+  if (sourceUserId === targetUserId) {
+    return {
+      status: 400,
+      jsonBody: { error: "sourceUserId and targetUserId must be different" },
+    };
+  }
+
+  try {
+    const result = await transaction<AdminUserMergeResponse>(async (client) => {
+      const users = await client.query<{
+        userId: number;
+        role: string | null;
+        email: string | null;
+        externalId: string | null;
+      }>(
+        `SELECT
+           user_id AS "userId",
+           COALESCE(role, 'user') AS role,
+           email,
+           external_id AS "externalId"
+         FROM app_user
+         WHERE user_id = ANY($1::bigint[])
+         FOR UPDATE`,
+        [[sourceUserId, targetUserId]]
+      );
+
+      if (users.rows.length !== 2) {
+        return {
+          merged: false,
+          sourceUserId,
+          targetUserId,
+          mergedByUserId: adminUserId,
+          mergedInventoryRows: 0,
+          mergedIdentityRows: 0,
+          mergedSubmissionRows: 0,
+          mergedCaptureRows: 0,
+          mergedCaptureAnswerRows: 0,
+          mergedClickEventRows: 0,
+          message: "One or both users do not exist",
+        };
+      }
+
+      const sourceUser = users.rows.find((row) => row.userId === sourceUserId)!;
+      const targetUser = users.rows.find((row) => row.userId === targetUserId)!;
+      const mergedTargetRole = targetUser.role === "admin" || sourceUser.role === "admin"
+        ? "admin"
+        : (targetUser.role || "user");
+
+      const mergeDuplicateInventory = await client.query(
+        `UPDATE user_inventory_item target
+         SET quantity = target.quantity + source.quantity
+         FROM user_inventory_item source
+         WHERE source.user_id = $1
+           AND target.user_id = $2
+           AND source.shade_id IS NOT NULL
+           AND target.shade_id = source.shade_id
+         RETURNING 1 AS "rowCount"`,
+        [sourceUserId, targetUserId]
+      );
+
+      await client.query(
+        `DELETE FROM user_inventory_item source
+         USING user_inventory_item target
+         WHERE source.user_id = $1
+           AND target.user_id = $2
+           AND source.shade_id IS NOT NULL
+           AND target.shade_id = source.shade_id`,
+        [sourceUserId, targetUserId]
+      );
+
+      const movedInventory = await client.query(
+        `UPDATE user_inventory_item
+         SET user_id = $1
+         WHERE user_id = $2`,
+        [targetUserId, sourceUserId]
+      );
+
+      const movedSubmissions = await client.query(
+        `UPDATE user_submission
+         SET user_id = $1
+         WHERE user_id = $2`,
+        [targetUserId, sourceUserId]
+      );
+
+      const movedCaptureSessions = await client.query(
+        `UPDATE capture_session
+         SET user_id = $1
+         WHERE user_id = $2`,
+        [targetUserId, sourceUserId]
+      );
+
+      const movedCaptureAnswers = await client.query(
+        `UPDATE capture_answer
+         SET user_id = $1
+         WHERE user_id = $2`,
+        [targetUserId, sourceUserId]
+      );
+
+      const movedClickEvents = await client.query(
+        `UPDATE click_event
+         SET user_id = $1
+         WHERE user_id = $2`,
+        [targetUserId, sourceUserId]
+      );
+
+      const movedIdentities = await client.query(
+        `INSERT INTO user_external_identities (user_id, external_id, email, last_seen_at)
+         SELECT $1, external_id, email, last_seen_at
+         FROM user_external_identities
+         WHERE user_id = $2
+         ON CONFLICT (external_id) DO UPDATE
+         SET
+           user_id = EXCLUDED.user_id,
+           email = COALESCE(EXCLUDED.email, user_external_identities.email),
+           last_seen_at = GREATEST(user_external_identities.last_seen_at, EXCLUDED.last_seen_at)`,
+        [targetUserId, sourceUserId]
+      );
+
+      await client.query(
+        `UPDATE app_user
+         SET
+           role = $2,
+           email = COALESCE(email, $3),
+           external_id = COALESCE(external_id, $4)
+         WHERE user_id = $1`,
+        [targetUserId, mergedTargetRole, sourceUser.email, sourceUser.externalId]
+      );
+
+      await client.query(
+        `DELETE FROM app_user
+         WHERE user_id = $1`,
+        [sourceUserId]
+      );
+
+      return {
+        merged: true,
+        sourceUserId,
+        targetUserId,
+        mergedByUserId: adminUserId,
+        mergedInventoryRows: movedInventory.rowCount || 0,
+        mergedIdentityRows: movedIdentities.rowCount || 0,
+        mergedSubmissionRows: movedSubmissions.rowCount || 0,
+        mergedCaptureRows: movedCaptureSessions.rowCount || 0,
+        mergedCaptureAnswerRows: movedCaptureAnswers.rowCount || 0,
+        mergedClickEventRows: movedClickEvents.rowCount || 0,
+        message: `Merged user ${sourceUserId} into ${targetUserId}`,
+        mergedInventoryDuplicateRows: mergeDuplicateInventory.rowCount || 0,
+        targetRole: mergedTargetRole,
+      };
+    });
+
+    if (!result.merged) {
+      return { status: 404, jsonBody: result };
+    }
+
+    return {
+      status: 200,
+      jsonBody: result,
+    };
+  } catch (error: any) {
+    if (error?.code === "42P01") {
+      return {
+        status: 503,
+        jsonBody: { error: "Identity-link migrations are not applied yet" },
+      };
+    }
+    context.error("Error merging users:", error);
+    return {
+      status: 500,
+      jsonBody: { error: "Failed to merge users" },
+    };
+  }
+}
+
+function parseListLimit(value: string | null): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed)) return 100;
+  return Math.max(1, Math.min(500, parsed));
+}
+
+async function listUsers(
+  request: HttpRequest,
+  context: InvocationContext
+): Promise<HttpResponseInit> {
+  context.log("GET /api/admin/users");
+
+  const limit = parseListLimit(new URL(request.url).searchParams.get("limit"));
+
+  try {
+    const usersResult = await query<{
+      userId: number;
+      role: string | null;
+      email: string | null;
+      externalId: string | null;
+      handle: string | null;
+      createdAt: string;
+      inventoryCount: string;
+      submissionCount: string;
+      captureSessionCount: string;
+    }>(
+      `SELECT
+         u.user_id AS "userId",
+         COALESCE(u.role, 'user') AS role,
+         u.email,
+         u.external_id AS "externalId",
+         u.handle,
+         u.created_at::text AS "createdAt",
+         COUNT(DISTINCT ui.inventory_item_id)::text AS "inventoryCount",
+         COUNT(DISTINCT us.submission_id)::text AS "submissionCount",
+         COUNT(DISTINCT cs.capture_session_id)::text AS "captureSessionCount"
+       FROM app_user u
+       LEFT JOIN user_inventory_item ui ON ui.user_id = u.user_id
+       LEFT JOIN user_submission us ON us.user_id = u.user_id
+       LEFT JOIN capture_session cs ON cs.user_id = u.user_id
+       GROUP BY u.user_id, u.role, u.email, u.external_id, u.handle, u.created_at
+       ORDER BY u.user_id ASC
+       LIMIT $1`,
+      [limit]
+    );
+
+    const userIds = usersResult.rows.map((row) => row.userId);
+    const identityMap = new Map<number, string[]>();
+
+    if (userIds.length > 0) {
+      try {
+        const identitiesResult = await query<{
+          userId: number;
+          externalId: string;
+        }>(
+          `SELECT user_id AS "userId", external_id AS "externalId"
+           FROM user_external_identities
+           WHERE user_id = ANY($1::bigint[])
+           ORDER BY user_id ASC, created_at ASC, user_external_identity_id ASC`,
+          [userIds]
+        );
+
+        for (const row of identitiesResult.rows) {
+          const existing = identityMap.get(row.userId) || [];
+          existing.push(row.externalId);
+          identityMap.set(row.userId, existing);
+        }
+      } catch (identityError: any) {
+        if (identityError?.code !== "42P01") {
+          throw identityError;
+        }
+      }
+    }
+
+    const users: AdminUserListItem[] = usersResult.rows.map((row) => {
+      const linkedExternalIds = identityMap.get(row.userId) ?? [];
+      if (linkedExternalIds.length === 0 && row.externalId) {
+        linkedExternalIds.push(row.externalId);
+      }
+
+      return {
+        userId: row.userId,
+        role: row.role || "user",
+        email: row.email || undefined,
+        externalId: row.externalId || undefined,
+        linkedExternalIds,
+        handle: row.handle || undefined,
+        createdAt: row.createdAt,
+        inventoryCount: Number.parseInt(row.inventoryCount, 10) || 0,
+        submissionCount: Number.parseInt(row.submissionCount, 10) || 0,
+        captureSessionCount: Number.parseInt(row.captureSessionCount, 10) || 0,
+      };
+    });
+
+    return {
+      status: 200,
+      jsonBody: {
+        users,
+        total: users.length,
+      } satisfies AdminUserListResponse,
+    };
+  } catch (error) {
+    context.error("Error listing users:", error);
+    return {
+      status: 500,
+      jsonBody: { error: "Failed to list users" },
+    };
+  }
+}
+
+app.http("admin-users-list", {
+  methods: ["GET", "OPTIONS"],
+  authLevel: "anonymous",
+  route: "admin/users",
+  handler: withCors(withAdmin(async (request, context) => listUsers(request, context))),
+});
+
+app.http("admin-users-merge", {
+  methods: ["POST", "OPTIONS"],
+  authLevel: "anonymous",
+  route: "admin/users/merge",
+  handler: withCors(withAdmin(mergeUsers)),
+});

--- a/packages/functions/src/functions/admin-users.ts
+++ b/packages/functions/src/functions/admin-users.ts
@@ -168,6 +168,13 @@ async function mergeUsers(
       );
 
       await client.query(
+        `UPDATE app_settings
+         SET updated_by = NULL
+         WHERE updated_by = $1`,
+        [sourceUserId]
+      );
+
+      await client.query(
         `DELETE FROM app_user
          WHERE user_id = $1`,
         [sourceUserId]

--- a/packages/functions/src/functions/admin-users.ts
+++ b/packages/functions/src/functions/admin-users.ts
@@ -228,6 +228,11 @@ async function listUsers(
   const limit = parseListLimit(new URL(request.url).searchParams.get("limit"));
 
   try {
+    const countResult = await query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total
+       FROM app_user`
+    );
+
     const usersResult = await query<{
       userId: number;
       role: string | null;
@@ -311,7 +316,7 @@ async function listUsers(
       status: 200,
       jsonBody: {
         users,
-        total: users.length,
+        total: Number.parseInt(countResult.rows[0]?.total ?? "0", 10) || 0,
       } satisfies AdminUserListResponse,
     };
   } catch (error) {

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,4 +1,5 @@
 export * from './functions/auth';
+export * from './functions/admin-users';
 export * from './functions/admin-reference';
 export * from './functions/capture';
 export * from './functions/catalog';

--- a/packages/functions/src/lib/auth.ts
+++ b/packages/functions/src/lib/auth.ts
@@ -271,6 +271,11 @@ async function getOrCreateUserWithLinkedIdentities(
     }
 
     if (email) {
+      // Acquire a transaction-scoped advisory lock on a hash of the normalized email
+      // so that concurrent first-time logins with the same address are serialized.
+      // The lock is released automatically when the transaction commits or rolls back.
+      await client.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [email]);
+
       const emailMatch = await client.query<{ userId: number }>(
         `SELECT user_id AS "userId"
          FROM app_user

--- a/packages/functions/src/lib/auth.ts
+++ b/packages/functions/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
 import { createRemoteJWKSet, jwtVerify } from "jose";
-import { query } from "./db";
+import { query, transaction } from "./db";
 import { trackEvent, trackException } from "./telemetry";
 
 export interface AuthResult {
@@ -220,6 +220,164 @@ async function getOrCreateUser(
   email?: string,
   role: EntraRole = "user"
 ): Promise<{ userId: number; role: string }> {
+  const normalizedEmail = normalizeEmail(email);
+
+  try {
+    return await getOrCreateUserWithLinkedIdentities(externalId, normalizedEmail, role);
+  } catch (error: any) {
+    // Backward-compatible fallback when the new table has not been migrated yet.
+    if (error?.code === "42P01") {
+      return getOrCreateUserLegacy(externalId, normalizedEmail, role);
+    }
+    throw error;
+  }
+}
+
+function normalizeEmail(email?: string): string | null {
+  if (!email) return null;
+  const normalized = email.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+async function getOrCreateUserWithLinkedIdentities(
+  externalId: string,
+  email: string | null,
+  role: EntraRole
+): Promise<{ userId: number; role: string }> {
+  return transaction(async (client) => {
+    const linkedIdentity = await client.query<{ userId: number }>(
+      `SELECT u.user_id AS "userId"
+       FROM user_external_identities uei
+       INNER JOIN app_user u ON u.user_id = uei.user_id
+       WHERE uei.external_id = $1
+       LIMIT 1`,
+      [externalId]
+    );
+
+    if (linkedIdentity.rows.length > 0) {
+      return updateUserAndTouchIdentity(linkedIdentity.rows[0].userId, externalId, email, role);
+    }
+
+    const legacyExternalId = await client.query<{ userId: number }>(
+      `SELECT user_id AS "userId"
+       FROM app_user
+       WHERE external_id = $1
+       LIMIT 1`,
+      [externalId]
+    );
+
+    if (legacyExternalId.rows.length > 0) {
+      return updateUserAndTouchIdentity(legacyExternalId.rows[0].userId, externalId, email, role);
+    }
+
+    if (email) {
+      const emailMatch = await client.query<{ userId: number }>(
+        `SELECT user_id AS "userId"
+         FROM app_user
+         WHERE lower(email) = lower($1)
+         ORDER BY user_id ASC
+         LIMIT 1
+         FOR UPDATE`,
+        [email]
+      );
+
+      if (emailMatch.rows.length > 0) {
+        return updateUserAndTouchIdentity(emailMatch.rows[0].userId, externalId, email, role);
+      }
+    }
+
+    const createdUser = await (async () => {
+      try {
+        return await client.query<{ userId: number; role: string | null }>(
+          `INSERT INTO app_user (external_id, email, handle, role)
+           VALUES ($1, $2, $3, $4)
+           RETURNING user_id AS "userId", role`,
+          [externalId, email, email || externalId, role]
+        );
+      } catch (error: any) {
+        if (error?.code === "42703") {
+          return client.query<{ userId: number; role: string | null }>(
+            `INSERT INTO app_user (external_id, email, handle)
+             VALUES ($1, $2, $3)
+             RETURNING user_id AS "userId", 'user'::text AS role`,
+            [externalId, email, email || externalId]
+          );
+        }
+        throw error;
+      }
+    })();
+
+    const created = createdUser.rows[0];
+    await upsertExternalIdentity(created.userId, externalId, email);
+
+    return {
+      userId: created.userId,
+      role: created.role || role,
+    };
+
+    async function updateUserAndTouchIdentity(
+      userId: number,
+      nextExternalId: string,
+      nextEmail: string | null,
+      nextRole: EntraRole
+    ): Promise<{ userId: number; role: string }> {
+      const updated = await (async () => {
+        try {
+          return await client.query<{ role: string | null }>(
+            `UPDATE app_user
+             SET
+               email = COALESCE($2, app_user.email),
+               role = $3
+             WHERE user_id = $1
+             RETURNING role`,
+            [userId, nextEmail, nextRole]
+          );
+        } catch (error: any) {
+          if (error?.code === "42703") {
+            return client.query<{ role: string | null }>(
+              `UPDATE app_user
+               SET email = COALESCE($2, app_user.email)
+               WHERE user_id = $1
+               RETURNING 'user'::text AS role`,
+              [userId, nextEmail]
+            );
+          }
+          throw error;
+        }
+      })();
+
+      await upsertExternalIdentity(userId, nextExternalId, nextEmail);
+
+      return {
+        userId,
+        role: updated.rows[0]?.role || nextRole,
+      };
+    }
+
+    async function upsertExternalIdentity(
+      userId: number,
+      linkedExternalId: string,
+      linkedEmail: string | null
+    ): Promise<void> {
+      await client.query(
+        `INSERT INTO user_external_identities (user_id, external_id, email, last_seen_at)
+         VALUES ($1, $2, $3, now())
+         ON CONFLICT (external_id) DO UPDATE
+         SET
+           user_id = EXCLUDED.user_id,
+           email = COALESCE(EXCLUDED.email, user_external_identities.email),
+           last_seen_at = now()`,
+        [userId, linkedExternalId, linkedEmail]
+      );
+    }
+  });
+}
+
+async function getOrCreateUserLegacy(
+  externalId: string,
+  email: string | null,
+  role: EntraRole
+): Promise<{ userId: number; role: string }> {
   const result = await (async () => {
     try {
       return await query<{ user_id: number; role: string | null }>(
@@ -230,7 +388,7 @@ async function getOrCreateUser(
            email = COALESCE(EXCLUDED.email, app_user.email),
            role = EXCLUDED.role
          RETURNING user_id, role`,
-        [externalId, email || null, email || externalId, role]
+        [externalId, email, email || externalId, role]
       );
     } catch (error: any) {
       if (error?.code === "42703") {
@@ -239,12 +397,13 @@ async function getOrCreateUser(
            VALUES ($1, $2, $3)
            ON CONFLICT (external_id) DO UPDATE SET email = COALESCE(EXCLUDED.email, app_user.email)
            RETURNING user_id, 'user'::text AS role`,
-          [externalId, email || null, email || externalId]
+          [externalId, email, email || externalId]
         );
       }
       throw error;
     }
   })();
+
   return {
     userId: result.rows[0].user_id,
     role: result.rows[0].role || role,

--- a/packages/functions/tests/handlers.unit.test.cjs
+++ b/packages/functions/tests/handlers.unit.test.cjs
@@ -213,6 +213,7 @@ require("../dist/functions/voice");
 require("../dist/functions/capture");
 require("../dist/functions/ingestion");
 require("../dist/functions/ingestion-worker");
+require("../dist/functions/admin-users");
 
 // Reset mocks between tests
 afterEach(() => {
@@ -395,6 +396,58 @@ describe("functions/auth — getAuthConfig", () => {
     assert.equal(res.jsonBody.clientId, "my-client-id");
     assert.ok(res.jsonBody.authority.includes("mytenant"));
     assert.ok(res.jsonBody.knownAuthorities[0].includes("mytenant"));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// functions/admin-users — route registration, validation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("functions/admin-users — route registration", () => {
+  it("registers admin-users-list GET route", () => {
+    expectMethods("admin-users-list", ["GET"]);
+    assert.equal(registeredRoutes["admin-users-list"].route, "admin/users");
+  });
+
+  it("registers admin-users-merge POST route", () => {
+    expectMethods("admin-users-merge", ["POST"]);
+    assert.equal(registeredRoutes["admin-users-merge"].route, "admin/users/merge");
+  });
+});
+
+describe("functions/admin-users — merge validation", () => {
+  it("returns 400 when ids are missing", async () => {
+    process.env.AUTH_DEV_BYPASS = "true";
+    queryMock = async () => ({
+      rows: [{ user_id: 2, external_id: "dev-user-2", email: "admin@test", role: "admin" }],
+    });
+    const handler = registeredRoutes["admin-users-merge"].handler;
+    const req = fakeRequest({
+      method: "POST",
+      url: "http://localhost:7071/api/admin/users/merge",
+      headers: { authorization: "Bearer dev:2" },
+      body: {},
+    });
+    const res = await handler(req, fakeContext());
+    assert.equal(res.status, 400);
+    assert.match(res.jsonBody.error, /sourceUserId/i);
+  });
+
+  it("returns 400 when ids are equal", async () => {
+    process.env.AUTH_DEV_BYPASS = "true";
+    queryMock = async () => ({
+      rows: [{ user_id: 2, external_id: "dev-user-2", email: "admin@test", role: "admin" }],
+    });
+    const handler = registeredRoutes["admin-users-merge"].handler;
+    const req = fakeRequest({
+      method: "POST",
+      url: "http://localhost:7071/api/admin/users/merge",
+      headers: { authorization: "Bearer dev:2" },
+      body: { sourceUserId: 2, targetUserId: 2 },
+    });
+    const res = await handler(req, fakeContext());
+    assert.equal(res.status, 400);
+    assert.match(res.jsonBody.error, /must be different/i);
   });
 });
 

--- a/packages/functions/tests/handlers.unit.test.cjs
+++ b/packages/functions/tests/handlers.unit.test.cjs
@@ -449,6 +449,64 @@ describe("functions/admin-users — merge validation", () => {
     assert.equal(res.status, 400);
     assert.match(res.jsonBody.error, /must be different/i);
   });
+
+  it("returns 200 and merge counters on successful merge", async () => {
+    process.env.AUTH_DEV_BYPASS = "true";
+    queryMock = async (...args) => {
+      if (args[0]?.includes("FROM app_user")) {
+        return {
+          rows: [{ user_id: 2, external_id: "dev-user-2", email: "admin@test", role: "admin" }],
+        };
+      }
+      return { rows: [] };
+    };
+
+    transactionMock = async (cb) => cb({
+      query: async (sql) => {
+        if (sql.includes("FROM app_user") && sql.includes("WHERE user_id = ANY")) {
+          return {
+            rows: [
+              { userId: 10, role: "user", email: "source@test.dev", externalId: "oid-source" },
+              { userId: 20, role: "user", email: "target@test.dev", externalId: "oid-target" },
+            ],
+          };
+        }
+        if (sql.includes("UPDATE user_inventory_item target")) return { rows: [], rowCount: 1 };
+        if (sql.includes("DELETE FROM user_inventory_item source")) return { rows: [], rowCount: 1 };
+        if (sql.includes("UPDATE user_inventory_item")) return { rows: [], rowCount: 2 };
+        if (sql.includes("UPDATE user_submission")) return { rows: [], rowCount: 3 };
+        if (sql.includes("UPDATE capture_session")) return { rows: [], rowCount: 4 };
+        if (sql.includes("UPDATE capture_answer")) return { rows: [], rowCount: 5 };
+        if (sql.includes("UPDATE click_event")) return { rows: [], rowCount: 6 };
+        if (sql.includes("INSERT INTO user_external_identities")) return { rows: [], rowCount: 2 };
+        if (sql.includes("UPDATE app_user")) return { rows: [], rowCount: 1 };
+        if (sql.includes("DELETE FROM app_user")) return { rows: [], rowCount: 1 };
+        return { rows: [], rowCount: 0 };
+      },
+    });
+
+    const handler = registeredRoutes["admin-users-merge"].handler;
+    const req = fakeRequest({
+      method: "POST",
+      url: "http://localhost:7071/api/admin/users/merge",
+      headers: { authorization: "Bearer dev:2" },
+      body: { sourceUserId: 10, targetUserId: 20 },
+    });
+    const res = await handler(req, fakeContext());
+
+    assert.equal(res.status, 200);
+    assert.equal(res.jsonBody.merged, true);
+    assert.equal(res.jsonBody.sourceUserId, 10);
+    assert.equal(res.jsonBody.targetUserId, 20);
+    assert.equal(res.jsonBody.mergedInventoryRows, 2);
+    assert.equal(res.jsonBody.mergedIdentityRows, 2);
+    assert.equal(res.jsonBody.mergedSubmissionRows, 3);
+    assert.equal(res.jsonBody.mergedCaptureRows, 4);
+    assert.equal(res.jsonBody.mergedCaptureAnswerRows, 5);
+    assert.equal(res.jsonBody.mergedClickEventRows, 6);
+    assert.equal(res.jsonBody.mergedInventoryDuplicateRows, 1);
+    assert.match(res.jsonBody.message, /Merged user 10 into 20/i);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -37,6 +37,10 @@ The package is automatically linked via npm workspaces — no publishing require
 | `User` | User entity (id, email, displayName, avatarUrl, authProvider, timestamps) |
 | `AuthProvider` | `"apple" \| "facebook" \| "google" \| "email"` |
 | `AuthConfig` | B2C configuration (authority, clientId, knownAuthorities, redirectUri, scopes) |
+| `AdminUserListItem` | Admin user-management table row (`userId`, role, linked identities, and activity counts) |
+| `AdminUserListResponse` | Admin user list payload wrapper (`users`, `total`) |
+| `AdminUserMergeRequest` | Admin payload for duplicate-account repair (`sourceUserId`, `targetUserId`) |
+| `AdminUserMergeResponse` | Admin merge result summary (moved row counts + merge status/message) |
 
 ### `types/voice.ts`
 

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -19,11 +19,19 @@ export interface AuthConfig {
   scopes: string[];
 }
 
+/**
+ * Admin request payload to merge a duplicate account into a primary account.
+ * `sourceUserId` is deleted after transfer; `targetUserId` is retained.
+ */
 export interface AdminUserMergeRequest {
   sourceUserId: number;
   targetUserId: number;
 }
 
+/**
+ * Admin-facing user row used by the user-management table.
+ * Includes identity metadata and quick activity counts used to evaluate merge targets.
+ */
 export interface AdminUserListItem {
   userId: number;
   role: string;
@@ -37,11 +45,22 @@ export interface AdminUserListItem {
   captureSessionCount: number;
 }
 
+/**
+ * Response shape for listing users in admin user management.
+ * `users` contains the current page of rows and `total` is the full user count.
+ */
 export interface AdminUserListResponse {
   users: AdminUserListItem[];
   total: number;
 }
 
+/**
+ * Response payload for admin duplicate-account merge operations.
+ * `merged` indicates success/failure and `message` is user-facing status text.
+ * Count fields describe rows transferred by domain; `mergedInventoryDuplicateRows`
+ * reports inventory rows consolidated due to same-user/same-shade collisions.
+ * `targetRole` is optional and reflects the resulting role on the kept account.
+ */
 export interface AdminUserMergeResponse {
   merged: boolean;
   sourceUserId: number;

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -18,3 +18,42 @@ export interface AuthConfig {
   redirectUri: string;
   scopes: string[];
 }
+
+export interface AdminUserMergeRequest {
+  sourceUserId: number;
+  targetUserId: number;
+}
+
+export interface AdminUserListItem {
+  userId: number;
+  role: string;
+  email?: string;
+  externalId?: string;
+  linkedExternalIds: string[];
+  handle?: string;
+  createdAt: string;
+  inventoryCount: number;
+  submissionCount: number;
+  captureSessionCount: number;
+}
+
+export interface AdminUserListResponse {
+  users: AdminUserListItem[];
+  total: number;
+}
+
+export interface AdminUserMergeResponse {
+  merged: boolean;
+  sourceUserId: number;
+  targetUserId: number;
+  mergedByUserId: number;
+  mergedInventoryRows: number;
+  mergedIdentityRows: number;
+  mergedSubmissionRows: number;
+  mergedCaptureRows: number;
+  mergedCaptureAnswerRows: number;
+  mergedClickEventRows: number;
+  message: string;
+  mergedInventoryDuplicateRows?: number;
+  targetRole?: string;
+}


### PR DESCRIPTION
## Summary
- add email-based external identity linking flow with a new user_external_identities migration/backfill
- add admin users API endpoints for listing users and merging duplicate accounts
- add User Management tab under /admin to search users and execute merges
- add shared API contracts and update docs across root/web/functions/shared

## Validation
- npm run build --workspace=packages/shared
- npm run build --workspace=packages/functions
- npm run build --workspace=apps/web
- npm run test --workspace=packages/functions
- npm run typecheck
- npm run lint

## Notes
- migration required before using identity linking and user merge workflows: 019_add_user_external_identities.sql


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User Management tab in the Admin Console with search, listing, and a merge workflow to consolidate duplicate accounts.
  * Admin API endpoints to list admin-visible users and perform merges.
  * External identity linking enhanced to support multiple providers per user and safer migration.

* **Documentation**
  * Updated admin and API docs describing user management, merge operations, and migration prerequisites.

* **Tests**
  * Added unit tests covering listing, filtering, and merge flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->