### PR TITLE
fix(web): use native vertical lightness slider

### DIFF
--- a/apps/web/src/app/(app)/polishes/search/page.tsx
+++ b/apps/web/src/app/(app)/polishes/search/page.tsx
@@ -769,7 +769,7 @@ function ColorSearchPageContent() {
                         className="h-[200px] w-2 accent-primary"
                         aria-label="Lightness"
                         aria-orientation="vertical"
-                        orient="vertical"
+                        {...({ orient: "vertical" } as object)}
                         style={{
                           writingMode: "vertical-lr",
                           direction: "rtl",

--- a/apps/web/src/app/(app)/polishes/search/page.tsx
+++ b/apps/web/src/app/(app)/polishes/search/page.tsx
@@ -758,7 +758,7 @@ function ColorSearchPageContent() {
 
                   <div className="flex h-[292px] flex-col items-center justify-between rounded-xl border bg-muted/35 px-2 py-3">
                     <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Light</span>
-                    <div className="flex h-[220px] items-center">
+                    <div className="flex items-center justify-center">
                       <input
                         type="range"
                         min={0}
@@ -766,10 +766,12 @@ function ColorSearchPageContent() {
                         step={0.01}
                         value={lightness}
                         onChange={(e) => setLightness(parseFloat(e.target.value))}
-                        className="h-2 w-[220px] -rotate-90 accent-primary"
+                        className="h-[200px] w-2 accent-primary"
                         aria-label="Lightness"
                         style={{
-                          background: `linear-gradient(to right, #000, ${hslToHex({ h: selectedHsl?.h ?? 0, s: selectedHsl?.s ?? 1, l: 0.5 })}, #fff)`,
+                          writingMode: "vertical-lr",
+                          direction: "rtl",
+                          background: `linear-gradient(to top, #000, ${hslToHex({ h: selectedHsl?.h ?? 0, s: selectedHsl?.s ?? 1, l: 0.5 })}, #fff)`,
                           borderRadius: "9999px",
                         }}
                       />

--- a/apps/web/src/app/(app)/polishes/search/page.tsx
+++ b/apps/web/src/app/(app)/polishes/search/page.tsx
@@ -768,6 +768,8 @@ function ColorSearchPageContent() {
                         onChange={(e) => setLightness(parseFloat(e.target.value))}
                         className="h-[200px] w-2 accent-primary"
                         aria-label="Lightness"
+                        aria-orientation="vertical"
+                        orient="vertical"
                         style={{
                           writingMode: "vertical-lr",
                           direction: "rtl",


### PR DESCRIPTION
## Summary
This PR replaces the rotated horizontal lightness range input with a native vertical slider in Color Search, then adjusts the layout width so the slider is fully visible at `xl`.

### What changed
- Replaced CSS rotation approach (`-rotate-90`, `w-[220px]`) with native vertical writing mode on the lightness slider.
- Added inline slider styles:
  - `writingMode: "vertical-lr"`
  - `direction: "rtl"` (so dragging up increases value)
- Updated slider dimensions to vertical semantics:
  - `h-[200px]` for track length
  - `w-2` for visual thickness
- Simplified the slider wrapper by removing rotation-compensation sizing.
- Updated the dynamic gradient direction from `to right` to `to top` so it aligns with the vertical axis.
- Widened the Color Search `xl` left grid column from `minmax(320px, 380px)` to `minmax(360px, 460px)` so the wheel + vertical slider block fits without clipping.

## Files changed
- `apps/web/src/app/(app)/polishes/search/page.tsx`

## Validation
- `npm run typecheck`
- Pre-push checks passed, including web build:
  - `npm run build:web`

## Issue
Closes #111
