### PR TITLE
fix(web): prevent polishes pagination url sync loop

### DIFF
--- a/apps/web/src/app/(app)/polishes/page.tsx
+++ b/apps/web/src/app/(app)/polishes/page.tsx
@@ -237,17 +237,18 @@ function PolishesPageContent({ isAdmin }: { isAdmin: boolean }) {
 
   // Keep local state in sync with browser URL changes (back/forward).
   useEffect(() => {
-    const nextSearch = searchParams.get("q") ?? "";
-    const nextScope = parseResultsScope(searchParams.get("scope"), searchParams.get("all"));
-    const nextToneFilter = parseToneFilter(searchParams.get("tone"));
-    const nextFinishFilter = parseFinishFilter(searchParams.get("finish"));
+    const urlParams = new URLSearchParams(searchParamsString);
+    const nextSearch = urlParams.get("q") ?? "";
+    const nextScope = parseResultsScope(urlParams.get("scope"), urlParams.get("all"));
+    const nextToneFilter = parseToneFilter(urlParams.get("tone"));
+    const nextFinishFilter = parseFinishFilter(urlParams.get("finish"));
     const nextAvailabilityFilter = parseAvailabilityFilter(
-      searchParams.get("availability") ?? searchParams.get("avail")
+      urlParams.get("availability") ?? urlParams.get("avail")
     );
-    const nextSortKey = parseSortKey(searchParams.get("sort"));
-    const nextSortDirection = parseSortDirection(searchParams.get("dir"));
-    const nextPage = parsePositiveInt(searchParams.get("page"), 1);
-    const nextPageSize = parsePageSize(searchParams.get("pageSize"));
+    const nextSortKey = parseSortKey(urlParams.get("sort"));
+    const nextSortDirection = parseSortDirection(urlParams.get("dir"));
+    const nextPage = parsePositiveInt(urlParams.get("page"), 1);
+    const nextPageSize = parsePageSize(urlParams.get("pageSize"));
 
     const filtersChangedFromUrl =
       search !== nextSearch ||
@@ -277,20 +278,7 @@ function PolishesPageContent({ isAdmin }: { isAdmin: boolean }) {
     setSortDirection(nextSortDirection);
     setPage(nextPage);
     setPageSize(nextPageSize);
-  }, [
-    availabilityFilter,
-    debouncedSearch,
-    finishFilter,
-    page,
-    pageSize,
-    scope,
-    search,
-    searchParams,
-    searchParamsString,
-    sortDirection,
-    sortKey,
-    toneFilter,
-  ]);
+  }, [searchParamsString]);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {


### PR DESCRIPTION
## Summary
Fixes a pagination feedback loop on `/polishes` where navigating to page 2 could bounce due to URL/state sync re-runs.

## Changes
- Restrict URL->state sync effect to run only when the URL query string changes.
- Parse URL values from `searchParamsString` inside the effect.
- Remove local state values from that effect dependency list to avoid self-triggered resets.

## Validation
- `npm run typecheck`
- `npm test` (workspaces)
- `npm run build:web`

## Impact
- Pagination navigation (including page 2+) on `/polishes` is stable on `dev`.
