### PR TITLE
fix(infra): pass batch deployment vars to Terraform in CI

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -70,6 +70,11 @@ jobs:
       TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       TF_VAR_openai_endpoint: ${{ vars.OPENAI_ENDPOINT || '' }}
       TF_VAR_openai_deployment_name: ${{ vars.OPENAI_DEPLOYMENT_NAME || 'hex-detector' }}
+      TF_VAR_openai_batch_deployment_name: ${{ vars.OPENAI_BATCH_DEPLOYMENT_NAME || 'hex-detector-batch' }}
+      TF_VAR_openai_batch_model_name: ${{ vars.OPENAI_BATCH_MODEL_NAME || '' }}
+      TF_VAR_openai_batch_model_version: ${{ vars.OPENAI_BATCH_MODEL_VERSION || '' }}
+      TF_VAR_openai_batch_deployment_sku_name: ${{ vars.OPENAI_BATCH_DEPLOYMENT_SKU_NAME || 'GlobalBatch' }}
+      TF_VAR_openai_batch_deployment_capacity: ${{ vars.OPENAI_BATCH_DEPLOYMENT_CAPACITY || '100' }}
       OPENAI_ACCOUNT_NAME: ${{ vars.OPENAI_ACCOUNT_NAME || '' }}
 
     steps:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -46,7 +46,8 @@ Required GitHub Actions configuration (per GitHub environment):
 - Secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
 - Variables: `TFSTATE_RESOURCE_GROUP`, `TFSTATE_STORAGE_ACCOUNT`, `TFSTATE_CONTAINER` (recommended: `tfstate`), `TFSTATE_BLOB_NAME` (recommended: `<environment>.terraform.tfstate`)
 - OpenAI mode variable: `CREATE_OPENAI_RESOURCES` (`true` to let Terraform manage OpenAI account/deployment; default in workflow is `true`)
-- Optional variables for shared/external OpenAI accounts (used when `CREATE_OPENAI_RESOURCES=false`): `OPENAI_ENDPOINT`, `OPENAI_ACCOUNT_NAME`, `OPENAI_DEPLOYMENT_NAME`
+- OpenAI deployment variables (exported as `TF_VAR_*`): `OPENAI_DEPLOYMENT_NAME` (default `hex-detector`), `OPENAI_BATCH_DEPLOYMENT_NAME` (default `hex-detector-batch`), optional `OPENAI_BATCH_MODEL_NAME`, `OPENAI_BATCH_MODEL_VERSION`, `OPENAI_BATCH_DEPLOYMENT_SKU_NAME`, `OPENAI_BATCH_DEPLOYMENT_CAPACITY`
+- Optional variables for shared/external OpenAI accounts (used when `CREATE_OPENAI_RESOURCES=false`): `OPENAI_ENDPOINT`, `OPENAI_ACCOUNT_NAME`
 Recommended auth config (propagated to Terraform `TF_VAR_*` inputs):
 - Secrets: `AZURE_AD_B2C_CLIENT_ID`
 - Variables: `AUTH_DEV_BYPASS`, `AZURE_AD_B2C_TENANT` (falls back to `NEXT_PUBLIC_B2C_TENANT` if unset)


### PR DESCRIPTION
## Summary
- wire Azure OpenAI batch Terraform variables into the deploy workflow env (`TF_VAR_openai_batch_*`)
- default batch deployment name to `hex-detector-batch` in CI so Terraform can create the managed batch deployment in dev/prod
- document the new GitHub environment variables in infrastructure README

## Why this fix
`openai_hex_batch` creation depends on `openai_batch_deployment_name`, but the CI workflow was not exporting `TF_VAR_openai_batch_deployment_name`, so it remained empty and the batch deployment was skipped.

## Validation
- local commit hooks/tests
- pre-push infrastructure validation hook

## Rollout
1. Merge this PR to `dev`
2. Run **Deploy Infrastructure (dev)** workflow with `apply=true`
3. Confirm deployment `hex-detector-batch` exists in Azure OpenAI account
