### PR TITLE
fix(functions): evaluate batch flags at execution time

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -251,6 +251,8 @@ Key variables:
 | `REDIS_URL` | Redis endpoint URL for API read-through caching (for example `rediss://<host>:10000`). |
 | `REDIS_KEY` | Redis access key paired with `REDIS_URL`. When either Redis var is missing, cache helpers become no-ops and requests fall back to Postgres. |
 
+Batch runtime note: `HEX_DETECTION_BATCH_ENABLED` and `HEX_DETECTION_BATCH_MIN_IMAGES` are read when each ingestion worker message and batch poller run starts, so logs reflect the effective values used for that execution.
+
 JWT validation note:
 - In production mode (`AUTH_DEV_BYPASS=false`), auth discovery first tries Entra External ID (`ciamlogin.com`) metadata for `AZURE_AD_B2C_TENANT`, then falls back to legacy Azure AD B2C (`b2clogin.com`) metadata.
 - Accepted token audiences are `AZURE_AD_B2C_CLIENT_ID` and `api://AZURE_AD_B2C_CLIENT_ID` to support exposed-API scopes like `access_as_user`.

--- a/packages/functions/src/functions/ingestion-ai-batch-poller.ts
+++ b/packages/functions/src/functions/ingestion-ai-batch-poller.ts
@@ -17,6 +17,11 @@ import {
 const DEFAULT_BATCH_POLL_SCHEDULE = "0 */2 * * * *";
 const DEFAULT_MAX_JOBS_PER_POLL = 10;
 
+interface BatchPollerRuntimeConfig {
+  enabled: boolean;
+  maxJobsPerPoll: number;
+}
+
 function envFlagTrue(value: string | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
@@ -31,15 +36,20 @@ function parseIntEnv(value: string | undefined, fallback: number, min: number, m
   return Math.min(max, Math.max(min, parsed));
 }
 
-const BATCH_POLLER_ENABLED = envFlagTrue(process.env.HEX_DETECTION_BATCH_ENABLED);
 const BATCH_POLL_SCHEDULE =
   process.env.INGESTION_AI_BATCH_POLL_SCHEDULE?.trim() || DEFAULT_BATCH_POLL_SCHEDULE;
-const MAX_JOBS_PER_POLL = parseIntEnv(
-  process.env.INGESTION_AI_BATCH_MAX_POLL_JOBS,
-  DEFAULT_MAX_JOBS_PER_POLL,
-  1,
-  100
-);
+
+function getBatchPollerRuntimeConfig(): BatchPollerRuntimeConfig {
+  return {
+    enabled: envFlagTrue(process.env.HEX_DETECTION_BATCH_ENABLED),
+    maxJobsPerPoll: parseIntEnv(
+      process.env.INGESTION_AI_BATCH_MAX_POLL_JOBS,
+      DEFAULT_MAX_JOBS_PER_POLL,
+      1,
+      100
+    ),
+  };
+}
 
 function withPipelineMetrics(
   baseMetrics: Record<string, unknown>,
@@ -215,21 +225,23 @@ async function ingestionAiBatchPoller(
   _timer: Timer,
   context: InvocationContext
 ): Promise<void> {
-  if (!BATCH_POLLER_ENABLED) {
+  const runtimeConfig = getBatchPollerRuntimeConfig();
+
+  if (!runtimeConfig.enabled) {
     context.log(
       "[ingestion-ai-batch-poller] Skipping run because HEX_DETECTION_BATCH_ENABLED is false"
     );
     return;
   }
 
-  const awaitingJobs = await listIngestionJobsAwaitingAiBatch(MAX_JOBS_PER_POLL);
+  const awaitingJobs = await listIngestionJobsAwaitingAiBatch(runtimeConfig.maxJobsPerPoll);
   if (awaitingJobs.length === 0) {
     context.log("[ingestion-ai-batch-poller] No awaiting_ai jobs found");
     return;
   }
 
   context.log(
-    `[ingestion-ai-batch-poller] Processing ${awaitingJobs.length} awaiting_ai job(s)`
+    `[ingestion-ai-batch-poller] Processing ${awaitingJobs.length} awaiting_ai job(s), maxJobsPerPoll=${runtimeConfig.maxJobsPerPoll}`
   );
 
   for (const job of awaitingJobs) {

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -59,13 +59,10 @@ function envFlagTrue(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-const HEX_DETECTION_BATCH_ENABLED = envFlagTrue(process.env.HEX_DETECTION_BATCH_ENABLED);
-const HEX_DETECTION_BATCH_MIN_IMAGES = clampInt(
-  process.env.HEX_DETECTION_BATCH_MIN_IMAGES,
-  DEFAULT_HEX_BATCH_MIN_IMAGES,
-  1,
-  1000
-);
+interface HexBatchRuntimeConfig {
+  enabled: boolean;
+  minImages: number;
+}
 
 const ingestionJobQueueOutput = output.storageQueue({
   queueName: INGESTION_JOB_QUEUE_NAME,
@@ -109,6 +106,18 @@ function clampInt(
   }
 
   return Math.min(maxValue, Math.max(minValue, parsed));
+}
+
+function getHexBatchRuntimeConfig(): HexBatchRuntimeConfig {
+  return {
+    enabled: envFlagTrue(process.env.HEX_DETECTION_BATCH_ENABLED),
+    minImages: clampInt(
+      process.env.HEX_DETECTION_BATCH_MIN_IMAGES,
+      DEFAULT_HEX_BATCH_MIN_IMAGES,
+      1,
+      1000
+    ),
+  };
 }
 
 function isSupportedSource(value: string): value is SupportedConnectorSource {
@@ -319,6 +328,7 @@ export async function processIngestionJobQueueMessage(
   context: InvocationContext
 ): Promise<void> {
   const requestedMetrics = payload.requestedMetrics || buildRequestedMetrics(payload.request, payload.userId);
+  const hexBatchConfig = getHexBatchRuntimeConfig();
   let stage = "worker_started";
 
   // Initialize logger with base metrics - flushes every 3s automatically
@@ -337,6 +347,8 @@ export async function processIngestionJobQueueMessage(
       source: payload.request.source,
       searchTerm: payload.request.searchTerm,
       maxRecords: payload.request.maxRecords,
+      hexBatchEnabled: hexBatchConfig.enabled,
+      hexBatchMinImages: hexBatchConfig.minImages,
     });
 
     const existingJob = await getIngestionJobById(payload.jobId);
@@ -469,18 +481,18 @@ export async function processIngestionJobQueueMessage(
       }));
 
       const materializeStartTime = Date.now();
-      logger.info(`Materializing ${payload.request.source} records to inventory`, {
-        recordCount: connectorResult.records.length,
-        userId: payload.userId,
-        dataSourceId: source.dataSourceId,
-        detectHexFromImage: payload.request.detectHexFromImage,
-        overwriteDetectedHex: payload.request.overwriteDetectedHex,
-        hexBatchEnabled: HEX_DETECTION_BATCH_ENABLED,
-        hexBatchMinImages: HEX_DETECTION_BATCH_MIN_IMAGES,
-      });
+        logger.info(`Materializing ${payload.request.source} records to inventory`, {
+          recordCount: connectorResult.records.length,
+          userId: payload.userId,
+          dataSourceId: source.dataSourceId,
+          detectHexFromImage: payload.request.detectHexFromImage,
+          overwriteDetectedHex: payload.request.overwriteDetectedHex,
+          hexBatchEnabled: hexBatchConfig.enabled,
+          hexBatchMinImages: hexBatchConfig.minImages,
+        });
 
-      try {
-        materializationMetrics = (await materializeHoloTacoRecords(
+        try {
+          materializationMetrics = (await materializeHoloTacoRecords(
           payload.userId,
           source.dataSourceId,
           connectorResult.records,
@@ -488,8 +500,8 @@ export async function processIngestionJobQueueMessage(
             detectHexFromImage: payload.request.detectHexFromImage,
             detectHexOnSuspiciousOnly: payload.request.detectHexOnSuspiciousOnly,
             overwriteDetectedHex: payload.request.overwriteDetectedHex,
-            useBatchForHexDetection: HEX_DETECTION_BATCH_ENABLED,
-            batchMinImages: HEX_DETECTION_BATCH_MIN_IMAGES,
+            useBatchForHexDetection: hexBatchConfig.enabled,
+            batchMinImages: hexBatchConfig.minImages,
             progressLogger: {
               info: (message, data) => logger.info(message, data),
               warn: (message, data) => logger.warn(message, data),

--- a/packages/functions/src/lib/ingestion-repo.ts
+++ b/packages/functions/src/lib/ingestion-repo.ts
@@ -314,6 +314,14 @@ async function prepareHoloTacoImageData(
   console.log(
     `${sourceLogPrefix} Image preparation: processing ${records.length} records, detectHexFromImage=${detectHexFromImage}, detectHexOnSuspiciousOnly=${detectHexOnSuspiciousOnly}, estimatedBatchCandidates=${estimatedBatchCandidates}, useBatchForHexDetection=${useBatchForHexDetection}, batchMinImages=${batchMinImages}`
   );
+  progressLogger?.info(`${sourceLogPrefix} Image preparation config`, {
+    records: records.length,
+    detectHexFromImage,
+    detectHexOnSuspiciousOnly,
+    estimatedBatchCandidates,
+    useBatchForHexDetection,
+    batchMinImages,
+  });
 
   for (const record of records) {
     const emptyPrepared: HoloTacoPreparedImage = {


### PR DESCRIPTION
## Summary
- resolve batch runtime flags per execution instead of at module load for ingestion worker and batch poller
- include resolved `hexBatchEnabled`/`hexBatchMinImages` in worker-start logs for every job
- add image-preparation config telemetry (`estimatedBatchCandidates`, `useBatchForHexDetection`, threshold) to job logs for easier root-cause analysis
- document the runtime flag behavior in Functions README

## Why
Changing `HEX_DETECTION_BATCH_ENABLED` in Azure should be reflected by newly executing jobs. This patch ensures the worker and poller read current env values at execution start and emit the effective values in logs.

## Validation
- `npm run test --workspace=packages/functions`

## Rollout
1. Merge this PR into `dev`
2. Redeploy Functions (or restart app) so the latest code is active
3. Run a Shopify ingestion job and confirm logs include:
   - worker start with `hexBatchEnabled: true`
   - image prep config showing `useBatchForHexDetection` decision
