### PR TITLE
perf(functions): parallelize image uploads in ingestion pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14656,6 +14656,8 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -18156,6 +18158,7 @@
         "@azure/storage-queue": "^12.17.0",
         "applicationinsights": "^3.13.0",
         "jose": "^6.1.3",
+        "p-limit": "^3.1.0",
         "pg": "^8.18.0",
         "redis": "^5.11.0",
         "sharp": "^0.34.5",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -19,6 +19,7 @@
     "@azure/storage-queue": "^12.17.0",
     "applicationinsights": "^3.13.0",
     "jose": "^6.1.3",
+    "p-limit": "^3.1.0",
     "pg": "^8.18.0",
     "redis": "^5.11.0",
     "sharp": "^0.34.5",

--- a/packages/functions/src/lib/blob-storage.ts
+++ b/packages/functions/src/lib/blob-storage.ts
@@ -381,7 +381,19 @@ export async function blobExists(
     `${config.blobEndpoint}/${container}/${encodeBlobPath(blobName)}`
   );
   const response = await sendStorageRequest(config, "HEAD", blobUrl, {});
-  return response.status === 200;
+
+  if (response.status === 200) {
+    return true;
+  }
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  const details = await response.text().catch(() => "");
+  throw new Error(
+    `Failed to check blob existence for '${container}/${blobName}': ${response.status} ${response.statusText} ${details}`.trim()
+  );
 }
 
 export async function ensureContainer(

--- a/packages/functions/src/lib/blob-storage.ts
+++ b/packages/functions/src/lib/blob-storage.ts
@@ -221,7 +221,7 @@ async function runWithTimeout<T>(promise: Promise<T>, timeoutMs: number, label: 
 
 async function sendStorageRequest(
   config: StorageAccountConfig,
-  method: "PUT" | "GET",
+  method: "PUT" | "GET" | "HEAD",
   url: URL,
   headers: Record<string, string>,
   body?: Buffer
@@ -370,7 +370,44 @@ export async function readBlobFromStorageUrl(storageUrl: string): Promise<ReadBl
   };
 }
 
-export async function uploadSourceImageToBlob(params: UploadSourceImageOptions): Promise<UploadedBlobImage> {
+export async function blobExists(
+  connectionString: string,
+  containerName: string,
+  blobName: string
+): Promise<boolean> {
+  const config = parseStorageConnectionString(connectionString);
+  const container = normalizeContainerName(containerName);
+  const blobUrl = new URL(
+    `${config.blobEndpoint}/${container}/${encodeBlobPath(blobName)}`
+  );
+  const response = await sendStorageRequest(config, "HEAD", blobUrl, {});
+  return response.status === 200;
+}
+
+export async function ensureContainer(
+  connectionString: string,
+  containerName: string
+): Promise<void> {
+  const config = parseStorageConnectionString(connectionString);
+  const container = normalizeContainerName(containerName);
+  const containerUrl = new URL(`${config.blobEndpoint}/${container}`);
+  const response = await sendStorageRequest(
+    config,
+    "PUT",
+    new URL(`${containerUrl.toString()}?restype=container`),
+    { "Content-Length": "0" }
+  );
+  if (![201, 202, 409].includes(response.status)) {
+    const details = await response.text().catch(() => "");
+    throw new Error(
+      `Failed to ensure blob container '${container}': ${response.status} ${details}`
+    );
+  }
+}
+
+export async function uploadSourceImageToBlob(
+  params: UploadSourceImageOptions & { skipContainerEnsure?: boolean }
+): Promise<UploadedBlobImage> {
   console.log(`[blob-storage] Downloading image from ${params.sourceImageUrl}`);
   const sourceResponse = await runWithTimeout(
     fetch(params.sourceImageUrl, {
@@ -423,20 +460,9 @@ export async function uploadSourceImageToBlob(params: UploadSourceImageOptions):
   );
 
   const containerUrl = new URL(`${config.blobEndpoint}/${containerName}`);
-  console.log(`[blob-storage] Ensuring container exists: ${containerName}`);
-  const createContainerResponse = await sendStorageRequest(
-    config,
-    "PUT",
-    new URL(`${containerUrl.toString()}?restype=container`),
-    {
-      "Content-Length": "0",
-    }
-  );
-  if (![201, 202, 409].includes(createContainerResponse.status)) {
-    const details = await createContainerResponse.text().catch(() => "");
-    throw new Error(
-      `Failed to ensure blob container '${containerName}': ${createContainerResponse.status} ${details}`
-    );
+  if (!params.skipContainerEnsure) {
+    console.log(`[blob-storage] Ensuring container exists: ${containerName}`);
+    await ensureContainer(connectionString, containerName);
   }
 
   const blobUrl = new URL(`${containerUrl.toString()}/${encodeBlobPath(blobName)}`);

--- a/packages/functions/src/lib/ingestion-repo.ts
+++ b/packages/functions/src/lib/ingestion-repo.ts
@@ -4,7 +4,8 @@ import { SUPPORTED_SOURCES } from "./connectors/types";
 import { defaultShopifyBaseUrl } from "./connectors/shopify-generic";
 import { detectHexWithAzureOpenAI, type HexDetectionOptions } from "./ai-color-detection";
 import { submitVisionHexBatch } from "./azure-openai-batch";
-import { uploadSourceImageToBlob } from "./blob-storage";
+import { uploadSourceImageToBlob, ensureContainer, blobExists } from "./blob-storage";
+import pLimit = require("p-limit");
 import { isSuspiciousHex } from "./suspicious-hex";
 import { PoolClient } from "pg";
 
@@ -332,117 +333,152 @@ async function prepareHoloTacoImageData(
     batchMinImages,
   });
 
-  for (const record of records) {
-    const emptyPrepared: HoloTacoPreparedImage = {
-      storageUrl: null,
-      checksumSha256: null,
-      detectedHex: null,
-      detectedFinishes: null,
-      additionalImages: [],
-    };
+  // Ensure blob container exists once before parallel uploads
+  const connectionString = process.env.AZURE_STORAGE_CONNECTION?.trim() || null;
+  if (connectionString) {
+    const containerName = process.env.SOURCE_IMAGE_CONTAINER || "source-images";
+    console.log(`${sourceLogPrefix} Ensuring container exists before parallel uploads`);
+    await ensureContainer(connectionString, containerName);
+  }
 
-    const normalized =
-      record.normalized && typeof record.normalized === "object"
-        ? (record.normalized as Record<string, unknown>)
-        : null;
-    if (!normalized) {
-      console.log(`${sourceLogPrefix} Skipping record ${record.externalId}: no normalized data`);
-      byExternalId.set(record.externalId, emptyPrepared);
-      if (onRecordPrepared) {
-        await onRecordPrepared(record, emptyPrepared);
+  const sourceName = sourceLogPrefix.replace(/[\[\]]/g, "");
+
+  // --- Phase 1: Parallel image download/upload ---
+  interface ImageUploadResult {
+    record: ConnectorProductRecord;
+    holo: HoloTacoProductNormalized | null;
+    storageUrl: string | null;
+    checksumSha256: string | null;
+    imageBase64DataUri: string | null;
+    additionalImages: Array<{ storageUrl: string; checksumSha256: string }>;
+    isCandidate: boolean;
+  }
+
+  const limit = pLimit(4);
+  const startTime = Date.now();
+
+  const uploadTasks = records.map((record) =>
+    limit(async (): Promise<ImageUploadResult> => {
+      const normalized =
+        record.normalized && typeof record.normalized === "object"
+          ? (record.normalized as Record<string, unknown>)
+          : null;
+      if (!normalized) {
+        console.log(`${sourceLogPrefix} Skipping record ${record.externalId}: no normalized data`);
+        return { record, holo: null, storageUrl: null, checksumSha256: null, imageBase64DataUri: null, additionalImages: [], isCandidate: false };
       }
-      continue;
-    }
 
-    const holo = parseHoloTacoNormalized(normalized);
-    if (!holo.name) {
-      byExternalId.set(record.externalId, emptyPrepared);
-      if (onRecordPrepared) {
-        await onRecordPrepared(record, emptyPrepared);
+      const holo = parseHoloTacoNormalized(normalized);
+      if (!holo.name || !isHttpUrl(holo.primaryImageUrl)) {
+        if (holo.name) {
+          console.log(`${sourceLogPrefix} Skipping record ${record.externalId}: invalid image URL`, {
+            name: holo.name,
+            imageUrl: holo.primaryImageUrl,
+          });
+        }
+        return { record, holo, storageUrl: null, checksumSha256: null, imageBase64DataUri: null, additionalImages: [], isCandidate: false };
       }
-      continue;
-    }
 
-    if (!isHttpUrl(holo.primaryImageUrl)) {
-      console.log(`${sourceLogPrefix} Skipping record ${record.externalId}: missing name or invalid image URL`, {
-        name: holo.name,
-        imageUrl: holo.primaryImageUrl,
-      });
-      byExternalId.set(record.externalId, emptyPrepared);
-      if (onRecordPrepared) {
-        await onRecordPrepared(record, emptyPrepared);
-      }
-      continue;
-    }
+      console.log(`${sourceLogPrefix} Image candidate: externalId=${record.externalId}, name=${holo.name}, imageUrl=${holo.primaryImageUrl}`);
 
-    console.log(`${sourceLogPrefix} Image candidate: externalId=${record.externalId}, name=${holo.name}, imageUrl=${holo.primaryImageUrl}`);
-    metrics.imageCandidates += 1;
+      let storageUrl: string | null = null;
+      let checksumSha256: string | null = null;
+      let imageBase64DataUri: string | null = null;
+      const additionalImages: Array<{ storageUrl: string; checksumSha256: string }> = [];
 
-    let storageUrl: string | null = null;
-    let checksumSha256: string | null = null;
-    let detectedHex: string | null = null;
-    let detectedFinishes: string[] | null = null;
-    let imageBase64DataUri: string | null = null;
-    const additionalImages: Array<{ storageUrl: string; checksumSha256: string }> = [];
-
-    // Step 1: Upload primary image to blob storage
-    try {
-      console.log(`${sourceLogPrefix} BEFORE: Uploading primary image for ${record.externalId} from ${holo.primaryImageUrl}`);
-      const upload = await uploadSourceImageToBlob({
-        sourceImageUrl: holo.primaryImageUrl,
-        source: sourceLogPrefix.replace(/[\[\]]/g, ""),
-        externalId: record.externalId,
-      });
-      storageUrl = upload.storageUrl;
-      checksumSha256 = upload.checksumSha256;
-      imageBase64DataUri = upload.imageBase64DataUri;
-      metrics.imageUploads += 1;
-      console.log(`${sourceLogPrefix} AFTER: Primary image uploaded: checksum=${checksumSha256}, storageUrl=${storageUrl}`);
-    } catch (err) {
-      metrics.imageUploadFailures += 1;
-      console.error(`${sourceLogPrefix} Primary image upload failed for ${record.externalId}:`, String(err));
-    }
-
-    // Step 2: Upload additional images (index 1+) — no AI detection on these
-    for (let i = 1; i < holo.imageUrls.length; i++) {
-      const imgUrl = holo.imageUrls[i];
-      if (!isHttpUrl(imgUrl)) continue;
+      // Upload primary image (container already ensured)
       try {
         const upload = await uploadSourceImageToBlob({
-          sourceImageUrl: imgUrl,
-          source: sourceLogPrefix.replace(/[\[\]]/g, ""),
-          externalId: `${record.externalId}-img${i}`,
+          sourceImageUrl: holo.primaryImageUrl,
+          source: sourceName,
+          externalId: record.externalId,
+          skipContainerEnsure: true,
         });
-        additionalImages.push({
-          storageUrl: upload.storageUrl,
-          checksumSha256: upload.checksumSha256,
-        });
-        metrics.additionalImagesUploaded += 1;
+        storageUrl = upload.storageUrl;
+        checksumSha256 = upload.checksumSha256;
+        imageBase64DataUri = upload.imageBase64DataUri;
+        console.log(`${sourceLogPrefix} Primary image uploaded for ${record.externalId}: checksum=${checksumSha256}`);
       } catch (err) {
-        console.error(`${sourceLogPrefix} Additional image ${i} upload failed for ${record.externalId}:`, String(err));
+        console.error(`${sourceLogPrefix} Primary image upload failed for ${record.externalId}:`, String(err));
       }
+
+      // Upload additional images
+      for (let i = 1; i < holo.imageUrls.length; i++) {
+        const imgUrl = holo.imageUrls[i];
+        if (!isHttpUrl(imgUrl)) continue;
+        try {
+          const upload = await uploadSourceImageToBlob({
+            sourceImageUrl: imgUrl,
+            source: sourceName,
+            externalId: `${record.externalId}-img${i}`,
+            skipContainerEnsure: true,
+          });
+          additionalImages.push({
+            storageUrl: upload.storageUrl,
+            checksumSha256: upload.checksumSha256,
+          });
+        } catch (err) {
+          console.error(`${sourceLogPrefix} Additional image ${i} upload failed for ${record.externalId}:`, String(err));
+        }
+      }
+
+      return { record, holo, storageUrl, checksumSha256, imageBase64DataUri, additionalImages, isCandidate: true };
+    })
+  );
+
+  const uploadResults = await Promise.all(uploadTasks);
+  const uploadElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`${sourceLogPrefix} Phase 1 (parallel image upload) completed in ${uploadElapsed}s for ${records.length} records`);
+
+  // --- Phase 2: Sequential AI detection + callbacks ---
+  for (const result of uploadResults) {
+    const { record, holo, additionalImages } = result;
+    const { storageUrl, checksumSha256, imageBase64DataUri } = result;
+
+    if (!result.isCandidate) {
+      const emptyPrepared: HoloTacoPreparedImage = {
+        storageUrl: null,
+        checksumSha256: null,
+        detectedHex: null,
+        detectedFinishes: null,
+        additionalImages: [],
+      };
+      byExternalId.set(record.externalId, emptyPrepared);
+      if (onRecordPrepared) {
+        await onRecordPrepared(record, emptyPrepared);
+      }
+      continue;
     }
 
-    // Step 3: AI hex detection on primary image only
-    // Conditions: detectHexFromImage must be true, and if detectHexOnSuspiciousOnly
-    // is set, only run when vendor hex is suspicious/missing
+    metrics.imageCandidates += 1;
+    if (storageUrl) {
+      metrics.imageUploads += 1;
+    } else {
+      metrics.imageUploadFailures += 1;
+    }
+    metrics.additionalImagesUploaded += additionalImages.length;
+
+    let detectedHex: string | null = null;
+    let detectedFinishes: string[] | null = null;
+
+    // AI hex detection on primary image only
     const shouldRunAiDetection = detectHexFromImage &&
-      (!detectHexOnSuspiciousOnly || isSuspiciousHex(holo.vendorHex));
+      holo && (!detectHexOnSuspiciousOnly || isSuspiciousHex(holo.vendorHex));
     const imageForAi = imageBase64DataUri;
 
-    if (shouldRunAiDetection) {
+    if (shouldRunAiDetection && holo) {
       if (!imageForAi) {
         metrics.hexDetectionSkipped += 1;
         const skipMessage = `${sourceLogPrefix} ${record.externalId} [ai-color-detection] Skipping AI: missing base64 image payload`;
         console.warn(skipMessage, {
           externalId: record.externalId,
-          brand: holo.brand || sourceLogPrefix.replace(/[\[\]]/g, ""),
+          brand: holo.brand || sourceName,
           colorName: holo.name,
           uploadSucceeded: Boolean(storageUrl),
         });
         progressLogger?.warn(skipMessage, {
           externalId: record.externalId,
-          brand: holo.brand || sourceLogPrefix.replace(/[\[\]]/g, ""),
+          brand: holo.brand || sourceName,
           colorName: holo.name,
           uploadSucceeded: Boolean(storageUrl),
         });
@@ -451,7 +487,7 @@ async function prepareHoloTacoImageData(
           customId: record.externalId,
           imageUrlOrDataUri: imageForAi,
           vendorContext: {
-            shadeName: holo.name,
+            shadeName: holo.name!,
             vendorHex: holo.vendorHex,
             description: holo.collection,
             tags: holo.tags,
@@ -492,7 +528,7 @@ async function prepareHoloTacoImageData(
               }
             },
             vendorContext: {
-              shadeName: holo.name,
+              shadeName: holo.name!,
               vendorHex: holo.vendorHex,
               description: holo.collection,
               tags: holo.tags,
@@ -526,7 +562,7 @@ async function prepareHoloTacoImageData(
             metrics.hexDetected += 1;
             const successData = {
               externalId: record.externalId,
-              brand: holo.brand || sourceLogPrefix.replace(/[\[\]]/g, ""),
+              brand: holo.brand || sourceName,
               colorName: holo.name,
               hex: detection.hex,
               finishes: detection.finishes,
@@ -546,7 +582,7 @@ async function prepareHoloTacoImageData(
       }
     } else {
       metrics.hexDetectionSkipped += 1;
-      if (detectHexOnSuspiciousOnly && holo.vendorHex && !isSuspiciousHex(holo.vendorHex)) {
+      if (holo && detectHexOnSuspiciousOnly && holo.vendorHex && !isSuspiciousHex(holo.vendorHex)) {
         console.log(`${sourceLogPrefix} Skipping AI for ${record.externalId}: vendor hex ${holo.vendorHex} not suspicious`);
       } else {
         console.log(`${sourceLogPrefix} Skipping AI detection for ${record.externalId} (detectHexFromImage=${detectHexFromImage})`);

--- a/packages/functions/src/lib/ingestion-repo.ts
+++ b/packages/functions/src/lib/ingestion-repo.ts
@@ -338,7 +338,25 @@ async function prepareHoloTacoImageData(
   if (connectionString) {
     const containerName = process.env.SOURCE_IMAGE_CONTAINER || "source-images";
     console.log(`${sourceLogPrefix} Ensuring container exists before parallel uploads`);
-    await ensureContainer(connectionString, containerName);
+    try {
+      await ensureContainer(connectionString, containerName);
+    } catch (error) {
+      console.error(
+        `${sourceLogPrefix} Failed to ensure container before parallel uploads; continuing with per-record handling`,
+        error
+      );
+      // Best-effort logging; do not abort the entire ingestion pipeline.
+      progressLogger?.error?.(
+        `${sourceLogPrefix} Failed to ensure container before parallel uploads; continuing with per-record handling`,
+        {
+          containerName,
+          error:
+            error instanceof Error
+              ? { message: error.message, stack: error.stack }
+              : String(error),
+        }
+      );
+    }
   }
 
   const sourceName = sourceLogPrefix.replace(/[\[\]]/g, "");


### PR DESCRIPTION
## Summary
- Refactor `prepareHoloTacoImageData` into two phases: parallel image download/strip/upload (concurrency 4 via `p-limit`), then sequential AI detection + DB callbacks
- Extract `ensureContainer()` and `blobExists()` from blob-storage, call container ensure once before parallel phase instead of per-upload
- Add `skipContainerEnsure` option to `uploadSourceImageToBlob` to avoid redundant container checks

## Test plan
- [x] `npm run build:functions` passes with no type errors
- [x] All existing unit tests pass
- [ ] Run a small Shopify ingestion job (maxRecords=5) and compare timing logs — expect ~4x speedup on image prep phase
- [ ] Verify batch queue still submits correctly after parallel prep
- [ ] Run same job twice to confirm no regressions from sequential behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-record prepared image state and callbacks for downstream processing
  * Per-record AI-detection flow with optional batch queuing

* **Improvements**
  * Parallelized image download/upload pipeline with concurrency control for better performance
  * Container management and blob-existence checks with configurable skip behavior
  * Enhanced logging, metrics, and resilient error handling during ingestion

* **Chores**
  * Added runtime concurrency dependency for upload control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->