### PR TITLE
feat(ingestion): bulk runner with exhaustive paging and admin UI

### DIFF
--- a/apps/web/src/app/(app)/admin/jobs/page.tsx
+++ b/apps/web/src/app/(app)/admin/jobs/page.tsx
@@ -995,16 +995,20 @@ const SOURCE_PROTOCOL_SUFFIX_RULES = [
 ] as const;
 
 function getSourceProtocol(name: string): string {
+  const directProtocol =
+    SOURCE_PROTOCOL_BY_NAME[name as keyof typeof SOURCE_PROTOCOL_BY_NAME];
+
+  if (directProtocol !== undefined) {
+    return directProtocol;
+  }
+
   for (const rule of SOURCE_PROTOCOL_SUFFIX_RULES) {
     if (name.endsWith(rule.suffix)) {
       return rule.protocol;
     }
   }
 
-  const directProtocol =
-    SOURCE_PROTOCOL_BY_NAME[name as keyof typeof SOURCE_PROTOCOL_BY_NAME];
-
-  return directProtocol ?? "Custom";
+  return "Custom";
 }
 
 interface BulkRunCardProps {

--- a/apps/web/src/app/(app)/admin/jobs/page.tsx
+++ b/apps/web/src/app/(app)/admin/jobs/page.tsx
@@ -983,12 +983,28 @@ export function AdminJobsContent() {
 
 // ─── Bulk Run Card ───────────────────────────────────────────────────────────
 
+const SOURCE_PROTOCOL_BY_NAME = {
+  OpenBeautyFacts: "OpenBeautyFacts",
+  MakeupAPI: "MakeupAPI",
+  CosIng: "GS1",
+  GS1Lookup: "GS1",
+} as const satisfies Record<string, string>;
+
+const SOURCE_PROTOCOL_SUFFIX_RULES = [
+  { suffix: "Shopify", protocol: "Shopify" },
+] as const;
+
 function getSourceProtocol(name: string): string {
-  if (name.endsWith("Shopify")) return "Shopify";
-  if (name === "OpenBeautyFacts") return "OpenBeautyFacts";
-  if (name === "MakeupAPI") return "MakeupAPI";
-  if (name === "CosIng" || name === "GS1Lookup") return "GS1";
-  return "Custom";
+  for (const rule of SOURCE_PROTOCOL_SUFFIX_RULES) {
+    if (name.endsWith(rule.suffix)) {
+      return rule.protocol;
+    }
+  }
+
+  const directProtocol =
+    SOURCE_PROTOCOL_BY_NAME[name as keyof typeof SOURCE_PROTOCOL_BY_NAME];
+
+  return directProtocol ?? "Custom";
 }
 
 interface BulkRunCardProps {

--- a/apps/web/src/app/(app)/admin/jobs/page.tsx
+++ b/apps/web/src/app/(app)/admin/jobs/page.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  BulkIngestionRequest,
   IngestionJobRecord,
   IngestionJobRunRequest,
   IngestionLogEntry,
@@ -515,7 +516,7 @@ export function AdminJobsContent() {
       setBulkMessage(null);
       setBulkError(null);
       const response = await runBulkIngestion({
-        sources: Array.from(bulkSelected),
+        sources: Array.from(bulkSelected) as BulkIngestionRequest["sources"],
         options: {
           materializeToInventory: bulkMaterialize === "true",
           detectHexFromImage: bulkDetectHex === "true",
@@ -983,34 +984,6 @@ export function AdminJobsContent() {
 
 // ─── Bulk Run Card ───────────────────────────────────────────────────────────
 
-const SOURCE_PROTOCOL_BY_NAME = {
-  OpenBeautyFacts: "OpenBeautyFacts",
-  MakeupAPI: "MakeupAPI",
-  CosIng: "GS1",
-  GS1Lookup: "GS1",
-} as const satisfies Record<string, string>;
-
-const SOURCE_PROTOCOL_SUFFIX_RULES = [
-  { suffix: "Shopify", protocol: "Shopify" },
-] as const;
-
-function getSourceProtocol(name: string): string {
-  const directProtocol =
-    SOURCE_PROTOCOL_BY_NAME[name as keyof typeof SOURCE_PROTOCOL_BY_NAME];
-
-  if (directProtocol !== undefined) {
-    return directProtocol;
-  }
-
-  for (const rule of SOURCE_PROTOCOL_SUFFIX_RULES) {
-    if (name.endsWith(rule.suffix)) {
-      return rule.protocol;
-    }
-  }
-
-  return "Custom";
-}
-
 interface BulkRunCardProps {
   availableSources: DataSource[];
   selected: Set<string>;
@@ -1044,19 +1017,14 @@ function BulkRunCard({
   error,
   onRun,
 }: BulkRunCardProps) {
-  // Group sources by protocol, only including Shopify and known API sources
+  // Group queueable sources by API-provided connector protocol.
   const groups = useMemo(() => {
     const map = new Map<string, string[]>();
     for (const s of availableSources) {
-      const protocol = getSourceProtocol(s.name);
-      // Only show sources that have a real connector implemented
-      if (
-        !s.name.endsWith("Shopify") &&
-        s.name !== "OpenBeautyFacts" &&
-        s.name !== "MakeupAPI"
-      ) {
+      if (s.queueable !== true) {
         continue;
       }
+      const protocol = s.protocol ?? "Custom";
       if (!map.has(protocol)) map.set(protocol, []);
       map.get(protocol)!.push(s.name);
     }
@@ -1119,6 +1087,7 @@ function BulkRunCard({
                       <button
                         key={name}
                         type="button"
+                        aria-pressed={isSelected}
                         onClick={() => onToggleSource(name)}
                         className={`rounded-md border px-2 py-0.5 text-xs transition-colors ${
                           isSelected

--- a/apps/web/src/app/(app)/admin/jobs/page.tsx
+++ b/apps/web/src/app/(app)/admin/jobs/page.tsx
@@ -14,6 +14,7 @@ import {
   listDataSources,
   listIngestionJobs,
   purgeQueue,
+  runBulkIngestion,
   runIngestionJob,
   type DataSource,
   type QueueStatsResponse,
@@ -303,6 +304,14 @@ export function AdminJobsContent() {
   const [purgeMessage, setPurgeMessage] = useState<string | null>(null);
   const [purgeError, setPurgeError] = useState<string | null>(null);
 
+  const [bulkSelected, setBulkSelected] = useState<Set<string>>(new Set());
+  const [bulkMaterialize, setBulkMaterialize] = useState<"true" | "false">("true");
+  const [bulkDetectHex, setBulkDetectHex] = useState<"true" | "false">("true");
+  const [bulkOverwriteHex, setBulkOverwriteHex] = useState<"true" | "false">("false");
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkMessage, setBulkMessage] = useState<string | null>(null);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+
   const refreshJobs = useCallback(async () => {
     const response = await listIngestionJobs({
       limit: 50,
@@ -496,6 +505,29 @@ export function AdminJobsContent() {
       setPurgeError(error instanceof Error ? error.message : "Failed to purge queue");
     } finally {
       setPurging(false);
+    }
+  }
+
+  async function handleBulkRun() {
+    if (bulkSelected.size === 0) return;
+    try {
+      setBulkBusy(true);
+      setBulkMessage(null);
+      setBulkError(null);
+      const response = await runBulkIngestion({
+        sources: Array.from(bulkSelected),
+        options: {
+          materializeToInventory: bulkMaterialize === "true",
+          detectHexFromImage: bulkDetectHex === "true",
+          overwriteDetectedHex: bulkOverwriteHex === "true",
+        },
+      });
+      setBulkMessage(`${response.enqueued} job${response.enqueued !== 1 ? "s" : ""} queued.`);
+      await refreshJobs();
+    } catch (error: unknown) {
+      setBulkError(error instanceof Error ? error.message : "Failed to queue bulk run");
+    } finally {
+      setBulkBusy(false);
     }
   }
 
@@ -747,6 +779,39 @@ export function AdminJobsContent() {
         </CardContent>
       </Card>
 
+      <BulkRunCard
+        availableSources={availableSources}
+        selected={bulkSelected}
+        onToggleSource={(name) =>
+          setBulkSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(name)) next.delete(name);
+            else next.add(name);
+            return next;
+          })
+        }
+        onToggleGroup={(names, select) =>
+          setBulkSelected((prev) => {
+            const next = new Set(prev);
+            for (const n of names) {
+              if (select) next.add(n);
+              else next.delete(n);
+            }
+            return next;
+          })
+        }
+        materialize={bulkMaterialize}
+        onMaterializeChange={setBulkMaterialize}
+        detectHex={bulkDetectHex}
+        onDetectHexChange={setBulkDetectHex}
+        overwriteHex={bulkOverwriteHex}
+        onOverwriteHexChange={setBulkOverwriteHex}
+        busy={bulkBusy}
+        message={bulkMessage}
+        error={bulkError}
+        onRun={() => void handleBulkRun()}
+      />
+
       <Card>
         <CardHeader className="gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
@@ -913,5 +978,185 @@ export function AdminJobsContent() {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+// ─── Bulk Run Card ───────────────────────────────────────────────────────────
+
+function getSourceProtocol(name: string): string {
+  if (name.endsWith("Shopify")) return "Shopify";
+  if (name === "OpenBeautyFacts") return "OpenBeautyFacts";
+  if (name === "MakeupAPI") return "MakeupAPI";
+  if (name === "CosIng" || name === "GS1Lookup") return "GS1";
+  return "Custom";
+}
+
+interface BulkRunCardProps {
+  availableSources: DataSource[];
+  selected: Set<string>;
+  onToggleSource: (name: string) => void;
+  onToggleGroup: (names: string[], select: boolean) => void;
+  materialize: "true" | "false";
+  onMaterializeChange: (v: "true" | "false") => void;
+  detectHex: "true" | "false";
+  onDetectHexChange: (v: "true" | "false") => void;
+  overwriteHex: "true" | "false";
+  onOverwriteHexChange: (v: "true" | "false") => void;
+  busy: boolean;
+  message: string | null;
+  error: string | null;
+  onRun: () => void;
+}
+
+function BulkRunCard({
+  availableSources,
+  selected,
+  onToggleSource,
+  onToggleGroup,
+  materialize,
+  onMaterializeChange,
+  detectHex,
+  onDetectHexChange,
+  overwriteHex,
+  onOverwriteHexChange,
+  busy,
+  message,
+  error,
+  onRun,
+}: BulkRunCardProps) {
+  // Group sources by protocol, only including Shopify and known API sources
+  const groups = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const s of availableSources) {
+      const protocol = getSourceProtocol(s.name);
+      // Only show sources that have a real connector implemented
+      if (
+        !s.name.endsWith("Shopify") &&
+        s.name !== "OpenBeautyFacts" &&
+        s.name !== "MakeupAPI"
+      ) {
+        continue;
+      }
+      if (!map.has(protocol)) map.set(protocol, []);
+      map.get(protocol)!.push(s.name);
+    }
+    return Array.from(map.entries()).map(([protocol, names]) => ({ protocol, names }));
+  }, [availableSources]);
+
+  const allSelectableNames = useMemo(
+    () => groups.flatMap((g) => g.names),
+    [groups]
+  );
+
+  const allSelected = allSelectableNames.length > 0 && allSelectableNames.every((n) => selected.has(n));
+  const someSelected = allSelectableNames.some((n) => selected.has(n));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bulk Ingestion Run</CardTitle>
+        <CardDescription>
+          Queue exhaustive full-catalog pulls for multiple sources. Each selected source gets its own job.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-3">
+          {/* Select All */}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onToggleGroup(allSelectableNames, !allSelected)}
+              className="text-xs font-medium text-muted-foreground hover:text-foreground"
+            >
+              {allSelected ? "Deselect all" : "Select all"}
+            </button>
+            {someSelected && !allSelected && (
+              <span className="text-xs text-muted-foreground">({selected.size} selected)</span>
+            )}
+          </div>
+
+          {/* Groups */}
+          {groups.map(({ protocol, names }) => {
+            const groupAllSelected = names.every((n) => selected.has(n));
+            return (
+              <div key={protocol} className="space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {protocol}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onToggleGroup(names, !groupAllSelected)}
+                    className="text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    {groupAllSelected ? "deselect all" : "select all"}
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {names.map((name) => {
+                    const isSelected = selected.has(name);
+                    return (
+                      <button
+                        key={name}
+                        type="button"
+                        onClick={() => onToggleSource(name)}
+                        className={`rounded-md border px-2 py-0.5 text-xs transition-colors ${
+                          isSelected
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                        }`}
+                      >
+                        {name.replace(/Shopify$/, "")}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Materialize to inventory</p>
+            <Select value={materialize} onValueChange={(v) => onMaterializeChange(v as "true" | "false")}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="true">Yes</SelectItem>
+                <SelectItem value="false">No</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Detect hex from image (AI)</p>
+            <Select value={detectHex} onValueChange={(v) => onDetectHexChange(v as "true" | "false")}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="true">Yes</SelectItem>
+                <SelectItem value="false">No</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Overwrite detected hex</p>
+            <Select value={overwriteHex} onValueChange={(v) => onOverwriteHexChange(v as "true" | "false")}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="false">No (fill blanks only)</SelectItem>
+                <SelectItem value="true">Yes (refresh all)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button onClick={onRun} disabled={busy || selected.size === 0}>
+            {busy ? "Queueing…" : `Run Bulk (${selected.size} source${selected.size !== 1 ? "s" : ""})`}
+          </Button>
+          {message && <p className="text-sm text-emerald-700">{message}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,6 @@
 import type {
+  BulkIngestionRequest,
+  BulkIngestionResponse,
   CaptureAnswerRequest,
   CaptureAnswerResponse,
   CaptureFinalizeResponse,
@@ -270,6 +272,17 @@ export async function runIngestionJob(
     body: JSON.stringify(data),
   });
   return handleResponse<IngestionJobRunResponse>(response);
+}
+
+export async function runBulkIngestion(
+  data: BulkIngestionRequest
+): Promise<BulkIngestionResponse> {
+  const response = await fetch(`${API_BASE_URL}/ingestion/bulk`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...await getAuthHeaders({ admin: true }) },
+    body: JSON.stringify(data),
+  });
+  return handleResponse<BulkIngestionResponse>(response);
 }
 
 export async function getIngestionJob(id: string | number): Promise<IngestionJobRunResponse> {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   BulkIngestionRequest,
   BulkIngestionResponse,
+  ConnectorProtocol,
   CaptureAnswerRequest,
   CaptureAnswerResponse,
   CaptureFinalizeResponse,
@@ -274,6 +275,13 @@ export async function runIngestionJob(
   return handleResponse<IngestionJobRunResponse>(response);
 }
 
+/**
+ * Call the admin-only POST /ingestion/bulk endpoint.
+ *
+ * Accepts a BulkIngestionRequest and returns a Promise that resolves to a
+ * BulkIngestionResponse containing the queued jobs. Adds admin auth headers
+ * with getAuthHeaders() and parses the response with handleResponse().
+ */
 export async function runBulkIngestion(
   data: BulkIngestionRequest
 ): Promise<BulkIngestionResponse> {
@@ -308,6 +316,8 @@ export interface DataSource {
   dataSourceId: number;
   name: string;
   baseUrl: string | null;
+  protocol?: ConnectorProtocol;
+  queueable?: boolean;
 }
 
 export interface ListDataSourcesResponse {

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -101,6 +101,51 @@ Adding a new reference category (example: `texture_type`):
 `POST /api/ingestion/jobs` now **queues** an async ingestion run and returns `202 Accepted` with a queued job record.
 Execution happens in a queue-triggered worker (`ingestion-worker.ts`) backed by Azure Storage Queue.
 
+`POST /api/ingestion/bulk` is admin-only and queues one exhaustive ingestion job per
+source. Use it when an admin needs to refresh complete catalogs across multiple
+connectors, for example reindexing all enabled Shopify sources after improving
+normalization or AI hex detection.
+
+Request payload:
+- `sources: IngestionSourceName[]` — supported source names with runnable connectors.
+- `options.materializeToInventory?: boolean` — defaults to `true`.
+- `options.detectHexFromImage?: boolean` — defaults to `true`.
+- `options.overwriteDetectedHex?: boolean` — defaults to `false`.
+
+Response payload:
+- `enqueued: number` — number of queue messages created.
+- `jobs: IngestionJobRecord[]` — queued ingestion job records.
+
+Example request:
+
+```json
+{
+  "sources": ["HoloTacoShopify", "MooncatShopify"],
+  "options": {
+    "materializeToInventory": true,
+    "detectHexFromImage": true,
+    "overwriteDetectedHex": false
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "enqueued": 2,
+  "jobs": [
+    {
+      "jobId": "123",
+      "source": "HoloTacoShopify",
+      "jobType": "connector_verify",
+      "status": "queued",
+      "startedAt": "2026-04-18T22:13:11.000Z"
+    }
+  ]
+}
+```
+
 Current source support:
 - `OpenBeautyFacts` (search-based pull)
 - `MakeupAPI` (nail-polish catalog pull)

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -39,6 +39,7 @@ Requires **Azure Functions Core Tools v4** (`npm i -g azure-functions-core-tools
 | `POST` | `/api/ingestion/jobs` | `enqueueIngestionJob` | `ingestion.ts` | ✅ Working |
 | `GET` | `/api/ingestion/jobs/{id}` | `ingestionJobDetailHandler` | `ingestion.ts` | ✅ Working |
 | `DELETE` | `/api/ingestion/jobs/{id}/cancel` | `ingestionJobCancelHandler` | `ingestion.ts` | ✅ Working |
+| `POST` | `/api/ingestion/bulk` | `bulkIngestionHandler` | `ingestion.ts` | ✅ Working (admin-only) |
 | `GET` | `/api/ingestion/sources` | `dataSourcesHandler` | `ingestion.ts` | ✅ Working |
 | `PATCH` | `/api/ingestion/sources/{id}/settings` | `sourceSettingsHandler` | `ingestion.ts` | ✅ Working |
 | `GET` | `/api/ingestion/settings` | `globalSettingsHandler` | `ingestion.ts` | ✅ Working |

--- a/packages/functions/src/functions/ingestion-worker.ts
+++ b/packages/functions/src/functions/ingestion-worker.ts
@@ -100,6 +100,10 @@ function parseNormalizedRequest(
     value.collectTrainingData === undefined
       ? false
       : parseBoolean(value.collectTrainingData);
+  const exhaustive =
+    value.exhaustive === undefined
+      ? false
+      : parseBoolean(value.exhaustive);
 
   let recentDays: number | undefined;
   if (value.recentDays === undefined || value.recentDays === null) {
@@ -121,7 +125,8 @@ function parseNormalizedRequest(
     materializeToInventory === null ||
     detectHexFromImage === null ||
     overwriteDetectedHex === null ||
-    collectTrainingData === null
+    collectTrainingData === null ||
+    exhaustive === null
   ) {
     return null;
   }
@@ -137,6 +142,7 @@ function parseNormalizedRequest(
     detectHexOnSuspiciousOnly: false,
     overwriteDetectedHex,
     collectTrainingData,
+    exhaustive,
     recentDays,
   };
 }

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -449,7 +449,7 @@ export async function processIngestionJobQueueMessage(
         lastMetadata = { ...pageResult.metadata };
         pagesFetched++;
 
-        if (pageResult.records.length === 0 || pageResult.records.length < payload.request.pageSize) {
+        if (pageResult.records.length === 0) {
           break;
         }
         currentPage++;

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -38,7 +38,12 @@ import { OpenBeautyFactsConnector } from "../lib/connectors/open-beauty-facts";
 import { MakeupApiConnector } from "../lib/connectors/makeup-api";
 import { HoloTacoShopifyConnector } from "../lib/connectors/holo-taco-shopify";
 import { ShopifyGenericConnector } from "../lib/connectors/shopify-generic";
-import { ProductConnector, SupportedConnectorSource, SUPPORTED_SOURCES } from "../lib/connectors/types";
+import {
+  ProductConnector,
+  SOURCE_PROTOCOL_MAP,
+  SupportedConnectorSource,
+  SUPPORTED_SOURCES,
+} from "../lib/connectors/types";
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 20;
@@ -130,6 +135,14 @@ function isSupportedSource(value: string): value is SupportedConnectorSource {
   return (SUPPORTED_SOURCES as readonly string[]).includes(value);
 }
 
+function hasRunnableConnector(source: SupportedConnectorSource): boolean {
+  return source === "OpenBeautyFacts" || source === "MakeupAPI" || source.endsWith("Shopify");
+}
+
+function isRunnableConnectorSource(value: string): value is SupportedConnectorSource {
+  return isSupportedSource(value) && hasRunnableConnector(value);
+}
+
 function createConnector(source: SupportedConnectorSource, baseUrl?: string | null): ProductConnector {
   if (source === "OpenBeautyFacts") {
     return new OpenBeautyFactsConnector(baseUrl);
@@ -153,6 +166,39 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
+const ADDITIVE_METRIC_KEYS = new Set([
+  "processed",
+  "inserted",
+  "updated",
+  "skipped",
+  "variantRowsProcessed",
+  "brandsCreated",
+  "shadesCreated",
+  "inventoryInserted",
+  "inventoryUpdated",
+  "legacyRowsDeleted",
+  "hexOverwritten",
+  "imageCandidates",
+  "imageUploads",
+  "imageUploadFailures",
+  "additionalImagesUploaded",
+  "swatchesLinked",
+  "hexDetected",
+  "hexDetectionFailures",
+  "hexDetectionSkipped",
+  "hexDetectionPromptTokens",
+  "hexDetectionCompletionTokens",
+  "hexDetectionTotalTokens",
+  "batchRequestsQueued",
+  "applied",
+  "skippedNoDetection",
+  "noShadeMatch",
+]);
+
+/**
+ * Merge per-page metric objects while only summing known additive counters.
+ * Non-additive values are overwritten by the latest incoming page metrics.
+ */
 function mergeMetrics(
   target: Record<string, unknown>,
   incoming: Record<string, unknown> | null | undefined
@@ -163,7 +209,11 @@ function mergeMetrics(
 
   for (const [key, value] of Object.entries(incoming)) {
     const currentValue = target[key];
-    if (typeof currentValue === "number" && typeof value === "number") {
+    if (
+      ADDITIVE_METRIC_KEYS.has(key) &&
+      typeof currentValue === "number" &&
+      typeof value === "number"
+    ) {
       target[key] = currentValue + value;
       continue;
     }
@@ -171,6 +221,47 @@ function mergeMetrics(
   }
 
   return target;
+}
+
+function asFinitePositiveNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function getExhaustiveStopReason(
+  pageResult: Awaited<ReturnType<ProductConnector["pullProducts"]>>,
+  currentPage: number
+): string | null {
+  if (pageResult.records.length === 0) {
+    return "empty page";
+  }
+
+  const metadata = pageResult.metadata ?? {};
+  if (metadata.hasMore === false) {
+    return "metadata.hasMore=false";
+  }
+
+  const sourcePageCount = asFinitePositiveNumber(metadata.sourcePageCount);
+  if (sourcePageCount !== null && currentPage >= sourcePageCount) {
+    return `sourcePageCount=${sourcePageCount}`;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(metadata, "nextPage") &&
+    (metadata.nextPage === null || metadata.nextPage === false || metadata.nextPage === "")
+  ) {
+    return "metadata.nextPage absent";
+  }
+
+  return null;
 }
 
 function buildRequestedMetrics(
@@ -607,12 +698,16 @@ export async function processIngestionJobQueueMessage(
       // Exhaustive mode: loop through all pages and process each page incrementally.
       let currentPage = payload.request.page;
       let pagesFetched = 0;
+      let lastPageRecordCount = 0;
+      let lastFetchedPage = currentPage;
+      let completedByConnectorSignal = false;
 
       logger.info(`Exhaustive mode: paging through all records from ${payload.request.source}`, {
         startPage: currentPage,
         pageSize: payload.request.pageSize,
       });
 
+      let capped = false;
       while (pagesFetched < EXHAUSTIVE_PAGE_LIMIT) {
         const pageResult = await connector.pullProducts({
           searchTerm: payload.request.searchTerm,
@@ -627,16 +722,38 @@ export async function processIngestionJobQueueMessage(
           ...pageResult.metadata,
         });
 
+        const stopReason = getExhaustiveStopReason(pageResult, currentPage);
         if (pageResult.records.length === 0) {
+          completedByConnectorSignal = true;
+          connectorMetadata = {
+            ...connectorMetadata,
+            ...pageResult.metadata,
+            pagesFetched,
+            exhaustive: true,
+            requestedExhaustive: true,
+            capped: false,
+            pageLimit: EXHAUSTIVE_PAGE_LIMIT,
+          };
+          logger.info(`Exhaustive mode stopping after page ${currentPage}: ${stopReason ?? "empty page"}`, {
+            page: currentPage,
+            pagesFetched,
+            source: payload.request.source,
+            recordCount: pageResult.records.length,
+          });
           break;
         }
 
         pagesFetched++;
+        lastFetchedPage = currentPage;
+        lastPageRecordCount = pageResult.records.length;
         connectorMetadata = {
           ...connectorMetadata,
           ...pageResult.metadata,
           pagesFetched,
           exhaustive: true,
+          requestedExhaustive: true,
+          capped: false,
+          pageLimit: EXHAUSTIVE_PAGE_LIMIT,
         };
 
         const shouldPauseForAiBatch = await persistPageRecords(pageResult);
@@ -644,10 +761,42 @@ export async function processIngestionJobQueueMessage(
           return;
         }
 
+        if (stopReason) {
+          completedByConnectorSignal = true;
+          logger.info(`Exhaustive mode stopping after page ${currentPage}: ${stopReason}`, {
+            page: currentPage,
+            pagesFetched,
+            source: payload.request.source,
+            recordCount: pageResult.records.length,
+          });
+          break;
+        }
+
         currentPage++;
       }
 
-      logger.info(`Exhaustive pull complete: ${totalRecordsProcessed} total records across ${pagesFetched} pages`);
+      if (!completedByConnectorSignal && pagesFetched >= EXHAUSTIVE_PAGE_LIMIT && lastPageRecordCount > 0) {
+        capped = true;
+        connectorMetadata = {
+          ...connectorMetadata,
+          pagesFetched,
+          exhaustive: false,
+          requestedExhaustive: true,
+          capped: true,
+          pageLimit: EXHAUSTIVE_PAGE_LIMIT,
+        };
+        logger.warn(`Exhaustive mode reached page safety cap for ${payload.request.source}`, {
+          source: payload.request.source,
+          pagesFetched,
+          currentPage: lastFetchedPage,
+          pageLimit: EXHAUSTIVE_PAGE_LIMIT,
+          totalRecordsProcessed,
+        });
+      }
+
+      logger.info(`Exhaustive pull complete: ${totalRecordsProcessed} total records across ${pagesFetched} pages`, {
+        capped,
+      });
     } else {
       const connectorResult = await connector.pullProducts({
         searchTerm: payload.request.searchTerm,
@@ -854,7 +1003,13 @@ async function handleListDataSources(_request: HttpRequest, context: InvocationC
     const sources = await listDataSources(true);
     return {
       status: 200,
-      jsonBody: { sources },
+      jsonBody: {
+        sources: sources.map((source) => ({
+          ...source,
+          protocol: isSupportedSource(source.name) ? SOURCE_PROTOCOL_MAP[source.name] : "Custom",
+          queueable: isRunnableConnectorSource(source.name),
+        })),
+      },
     };
   } catch (error) {
     context.error("Error listing data sources:", error);
@@ -1102,10 +1257,6 @@ async function bulkIngestionHandler(
     };
   }
 
-function hasRunnableConnector(source: SupportedConnectorSource): boolean {
-  return source === "OpenBeautyFacts" || source === "MakeupAPI" || source.endsWith("Shopify");
-}
-
   const dedupedSources = [...new Set(body.sources)];
   const invalidSources = dedupedSources.filter((s) => !isSupportedSource(s));
   if (invalidSources.length > 0) {
@@ -1127,6 +1278,11 @@ function hasRunnableConnector(source: SupportedConnectorSource): boolean {
   const queuedAt = new Date().toISOString();
   const queueMessages: string[] = [];
   const jobs: IngestionJobRecord[] = [];
+  const createdJobs: Array<{
+    jobId: number;
+    requestedMetrics: Record<string, unknown>;
+    source: SupportedConnectorSource;
+  }> = [];
 
   try {
     for (const source of sources) {
@@ -1164,6 +1320,7 @@ function hasRunnableConnector(source: SupportedConnectorSource): boolean {
         queuedMetrics,
         "queued"
       );
+      createdJobs.push({ jobId: job.jobId, requestedMetrics, source });
 
       const queueMessage: IngestionJobQueueMessage = {
         jobId: job.jobId,
@@ -1194,6 +1351,26 @@ function hasRunnableConnector(source: SupportedConnectorSource): boolean {
   } catch (error: unknown) {
     const message = getErrorMessage(error);
     context.error("Bulk ingestion enqueue failed:", error);
+
+    for (const createdJob of createdJobs) {
+      try {
+        await markIngestionJobFailed(
+          createdJob.jobId,
+          message,
+          withPipelineMetrics(createdJob.requestedMetrics, "failed", "queue_enqueue", {
+            queuedAt,
+            queueName: INGESTION_JOB_QUEUE_NAME,
+            bulkRun: true,
+            source: createdJob.source,
+            failedAt: new Date().toISOString(),
+            failedStage: "queue_enqueue",
+          })
+        );
+      } catch (markFailedError) {
+        context.error(`Failed to mark bulk ingestion job ${createdJob.jobId} as failed:`, markFailedError);
+      }
+    }
+
     return { status: 500, jsonBody: { error: message } };
   }
 }

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -627,6 +627,10 @@ export async function processIngestionJobQueueMessage(
           ...pageResult.metadata,
         });
 
+        if (pageResult.records.length === 0) {
+          break;
+        }
+
         pagesFetched++;
         connectorMetadata = {
           ...connectorMetadata,
@@ -634,10 +638,6 @@ export async function processIngestionJobQueueMessage(
           pagesFetched,
           exhaustive: true,
         };
-
-        if (pageResult.records.length === 0) {
-          break;
-        }
 
         const shouldPauseForAiBatch = await persistPageRecords(pageResult);
         if (shouldPauseForAiBatch) {

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -443,7 +443,7 @@ export async function processIngestionJobQueueMessage(
     let materializationMetricsAggregate: Record<string, unknown> | null = null;
     let totalRecordsProcessed = 0;
 
-    const handleConnectorResult = async (
+    const persistPageRecords = async (
       connectorResult: Awaited<ReturnType<typeof connector.pullProducts>>
     ): Promise<boolean> => {
       connectorMetadata = { ...connectorMetadata, ...connectorResult.metadata };
@@ -639,8 +639,8 @@ export async function processIngestionJobQueueMessage(
           break;
         }
 
-        const awaitingAi = await handleConnectorResult(pageResult);
-        if (awaitingAi) {
+        const shouldPauseForAiBatch = await persistPageRecords(pageResult);
+        if (shouldPauseForAiBatch) {
           return;
         }
 
@@ -658,8 +658,8 @@ export async function processIngestionJobQueueMessage(
       });
 
       connectorMetadata = { ...connectorMetadata, ...connectorResult.metadata };
-      const awaitingAi = await handleConnectorResult(connectorResult);
-      if (awaitingAi) {
+      const shouldPauseForAiBatch = await persistPageRecords(connectorResult);
+      if (shouldPauseForAiBatch) {
         return;
       }
     }

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -1044,6 +1044,10 @@ async function bulkIngestionHandler(
     return { status: 400, jsonBody: { error: "sources must be a non-empty array" } };
   }
 
+function hasRunnableConnector(source: SupportedConnectorSource): boolean {
+  return source === "OpenBeautyFacts" || source === "MakeupAPI" || source.endsWith("Shopify");
+}
+
   const invalidSources = body.sources.filter((s) => !isSupportedSource(s));
   if (invalidSources.length > 0) {
     return {
@@ -1053,6 +1057,13 @@ async function bulkIngestionHandler(
   }
 
   const sources = body.sources as SupportedConnectorSource[];
+  const nonRunnableSources = sources.filter((source) => !hasRunnableConnector(source));
+  if (nonRunnableSources.length > 0) {
+    return {
+      status: 400,
+      jsonBody: { error: `No ingestion connector available for: ${nonRunnableSources.join(", ")}` },
+    };
+  }
   const options = body.options ?? {};
   const queuedAt = new Date().toISOString();
   const queueMessages: string[] = [];

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -47,6 +47,7 @@ const DEFAULT_RECENT_DAYS = 120;
 const MAX_PAGE_SIZE = 100;
 const MAX_RECORDS = 200;
 const MAX_RECENT_DAYS = 3650;
+const MAX_BULK_SOURCES = SUPPORTED_SOURCES.length;
 const DEFAULT_SEARCH_TERM = "nail polish";
 const JOB_TYPE_CONNECTOR_VERIFY = "connector_verify";
 // Queue bindings resolve this to the AzureWebJobsStorage app setting.
@@ -1044,11 +1045,19 @@ async function bulkIngestionHandler(
     return { status: 400, jsonBody: { error: "sources must be a non-empty array" } };
   }
 
+  if (body.sources.length > MAX_BULK_SOURCES) {
+    return {
+      status: 400,
+      jsonBody: { error: `sources must not contain more than ${MAX_BULK_SOURCES} entries` },
+    };
+  }
+
 function hasRunnableConnector(source: SupportedConnectorSource): boolean {
   return source === "OpenBeautyFacts" || source === "MakeupAPI" || source.endsWith("Shopify");
 }
 
-  const invalidSources = body.sources.filter((s) => !isSupportedSource(s));
+  const dedupedSources = [...new Set(body.sources)];
+  const invalidSources = dedupedSources.filter((s) => !isSupportedSource(s));
   if (invalidSources.length > 0) {
     return {
       status: 400,
@@ -1056,7 +1065,7 @@ function hasRunnableConnector(source: SupportedConnectorSource): boolean {
     };
   }
 
-  const sources = body.sources as SupportedConnectorSource[];
+  const sources = dedupedSources as SupportedConnectorSource[];
   const nonRunnableSources = sources.filter((source) => !hasRunnableConnector(source));
   if (nonRunnableSources.length > 0) {
     return {

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -1,6 +1,9 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext, output } from "@azure/functions";
 import {
+  BulkIngestionRequest,
+  BulkIngestionResponse,
   IngestionJobListResponse,
+  IngestionJobRecord,
   IngestionJobRunRequest,
   IngestionJobRunResponse,
 } from "swatchwatch-shared";
@@ -84,6 +87,8 @@ interface NormalizedIngestionJobRequest {
   detectHexOnSuspiciousOnly: boolean;
   overwriteDetectedHex: boolean;
   collectTrainingData: boolean;
+  /** When true, loop through all pages until source returns empty (ignores maxRecords cap) */
+  exhaustive: boolean;
 }
 
 export interface IngestionJobQueueMessage {
@@ -233,6 +238,7 @@ async function enqueueIngestionJob(
     detectHexOnSuspiciousOnly: body.detectHexOnSuspiciousOnly === true,
     overwriteDetectedHex: body.overwriteDetectedHex === true,
     collectTrainingData: body.collectTrainingData === true,
+    exhaustive: body.exhaustive === true,
     recentDays:
       body.recentDays === null || body.recentDays === undefined
         ? undefined
@@ -409,13 +415,57 @@ export async function processIngestionJobQueueMessage(
     });
 
     const connector = createConnector(payload.request.source, source.baseUrl);
-    const connectorResult = await connector.pullProducts({
-      searchTerm: payload.request.searchTerm,
-      page: payload.request.page,
-      pageSize: payload.request.pageSize,
-      maxRecords: payload.request.maxRecords,
-      recentDays: payload.request.recentDays,
-    });
+
+    const EXHAUSTIVE_PAGE_LIMIT = 500;
+    let connectorResult: Awaited<ReturnType<typeof connector.pullProducts>>;
+
+    if (payload.request.exhaustive) {
+      // Exhaustive mode: loop through all pages until empty
+      let currentPage = payload.request.page;
+      const allRecords: (typeof connectorResult)["records"] = [];
+      let lastMetadata: Record<string, unknown> = {};
+      let pagesFetched = 0;
+
+      logger.info(`Exhaustive mode: paging through all records from ${payload.request.source}`, {
+        startPage: currentPage,
+        pageSize: payload.request.pageSize,
+      });
+
+      while (pagesFetched < EXHAUSTIVE_PAGE_LIMIT) {
+        const pageResult = await connector.pullProducts({
+          searchTerm: payload.request.searchTerm,
+          page: currentPage,
+          pageSize: payload.request.pageSize,
+          maxRecords: payload.request.pageSize,
+          recentDays: payload.request.recentDays,
+        });
+
+        logger.info(
+          `Exhaustive page ${currentPage}: ${pageResult.records.length} records`,
+          { page: currentPage, ...pageResult.metadata }
+        );
+
+        allRecords.push(...pageResult.records);
+        lastMetadata = { ...pageResult.metadata };
+        pagesFetched++;
+
+        if (pageResult.records.length === 0 || pageResult.records.length < payload.request.pageSize) {
+          break;
+        }
+        currentPage++;
+      }
+
+      connectorResult = { records: allRecords, source: payload.request.source, metadata: { ...lastMetadata, pagesFetched, exhaustive: true } };
+      logger.info(`Exhaustive pull complete: ${allRecords.length} total records across ${pagesFetched} pages`);
+    } else {
+      connectorResult = await connector.pullProducts({
+        searchTerm: payload.request.searchTerm,
+        page: payload.request.page,
+        pageSize: payload.request.pageSize,
+        maxRecords: payload.request.maxRecords,
+        recentDays: payload.request.recentDays,
+      });
+    }
 
     logger.info(`Connector returned ${connectorResult.records.length} records`, connectorResult.metadata);
 
@@ -976,6 +1026,108 @@ async function queueMessagesHandler(
   return { status: 405, jsonBody: { error: "Method not allowed" } };
 }
 
+async function bulkIngestionHandler(
+  request: HttpRequest,
+  context: InvocationContext,
+  userId: number
+): Promise<HttpResponseInit> {
+  context.log(`POST /api/ingestion/bulk by admin user ${userId}`);
+
+  let body: Partial<BulkIngestionRequest>;
+  try {
+    body = (await request.json()) as Partial<BulkIngestionRequest>;
+  } catch {
+    return { status: 400, jsonBody: { error: "Request body must be valid JSON" } };
+  }
+
+  if (!Array.isArray(body.sources) || body.sources.length === 0) {
+    return { status: 400, jsonBody: { error: "sources must be a non-empty array" } };
+  }
+
+  const invalidSources = body.sources.filter((s) => !isSupportedSource(s));
+  if (invalidSources.length > 0) {
+    return {
+      status: 400,
+      jsonBody: { error: `Unsupported sources: ${invalidSources.join(", ")}` },
+    };
+  }
+
+  const sources = body.sources as SupportedConnectorSource[];
+  const options = body.options ?? {};
+  const queuedAt = new Date().toISOString();
+  const queueMessages: string[] = [];
+  const jobs: IngestionJobRecord[] = [];
+
+  try {
+    for (const source of sources) {
+      const normalizedRequest: NormalizedIngestionJobRequest = {
+        source,
+        page: DEFAULT_PAGE,
+        pageSize: MAX_PAGE_SIZE,
+        maxRecords: DEFAULT_MAX_RECORDS,
+        searchTerm: DEFAULT_SEARCH_TERM,
+        materializeToInventory: options.materializeToInventory !== false,
+        detectHexFromImage: options.detectHexFromImage !== false,
+        detectHexOnSuspiciousOnly: false,
+        overwriteDetectedHex: options.overwriteDetectedHex === true,
+        collectTrainingData: false,
+        exhaustive: true,
+      };
+
+      const requestedMetrics = buildRequestedMetrics(normalizedRequest, userId);
+
+      const dataSource = await ensureDataSourceByName(source);
+      if (!dataSource) {
+        context.warn(`Bulk: data source '${source}' not found, skipping`);
+        continue;
+      }
+
+      const queuedMetrics = withPipelineMetrics(requestedMetrics, "queued", "queued", {
+        queuedAt,
+        queueName: INGESTION_JOB_QUEUE_NAME,
+        bulkRun: true,
+      });
+
+      const job = await createIngestionJob(
+        dataSource.dataSourceId,
+        JOB_TYPE_CONNECTOR_VERIFY,
+        queuedMetrics,
+        "queued"
+      );
+
+      const queueMessage: IngestionJobQueueMessage = {
+        jobId: job.jobId,
+        userId,
+        queuedAt,
+        request: normalizedRequest,
+        requestedMetrics,
+      };
+      queueMessages.push(JSON.stringify(queueMessage));
+
+      const loadedJob = await getIngestionJobById(job.jobId);
+      if (loadedJob) {
+        jobs.push(loadedJob);
+      }
+    }
+
+    if (queueMessages.length === 0) {
+      return { status: 400, jsonBody: { error: "No valid sources could be queued" } };
+    }
+
+    // Enqueue all messages at once — Azure Functions queue output accepts arrays
+    context.extraOutputs.set(ingestionJobQueueOutput, queueMessages);
+
+    return {
+      status: 202,
+      jsonBody: { enqueued: queueMessages.length, jobs } satisfies BulkIngestionResponse,
+    };
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    context.error("Bulk ingestion enqueue failed:", error);
+    return { status: 500, jsonBody: { error: message } };
+  }
+}
+
 app.http("ingestion-jobs", {
   methods: ["GET", "POST", "OPTIONS"],
   authLevel: "anonymous",
@@ -996,6 +1148,14 @@ app.http("ingestion-job-cancel", {
   authLevel: "anonymous",
   route: "ingestion/jobs/{id}/cancel",
   handler: withCors(withAdmin(ingestionJobCancelHandler)),
+});
+
+app.http("ingestion-bulk", {
+  methods: ["POST", "OPTIONS"],
+  authLevel: "anonymous",
+  route: "ingestion/bulk",
+  extraOutputs: [ingestionJobQueueOutput],
+  handler: withCors(withAdmin(bulkIngestionHandler)),
 });
 
 app.http("ingestion-sources", {

--- a/packages/functions/src/functions/ingestion.ts
+++ b/packages/functions/src/functions/ingestion.ts
@@ -153,6 +153,26 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
+function mergeMetrics(
+  target: Record<string, unknown>,
+  incoming: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  if (!incoming) {
+    return target;
+  }
+
+  for (const [key, value] of Object.entries(incoming)) {
+    const currentValue = target[key];
+    if (typeof currentValue === "number" && typeof value === "number") {
+      target[key] = currentValue + value;
+      continue;
+    }
+    target[key] = value;
+  }
+
+  return target;
+}
+
 function buildRequestedMetrics(
   request: NormalizedIngestionJobRequest,
   userId: number
@@ -418,13 +438,174 @@ export async function processIngestionJobQueueMessage(
     const connector = createConnector(payload.request.source, source.baseUrl);
 
     const EXHAUSTIVE_PAGE_LIMIT = 500;
-    let connectorResult: Awaited<ReturnType<typeof connector.pullProducts>>;
+    let connectorMetadata: Record<string, unknown> = {};
+    const persistenceMetricsAggregate: Record<string, unknown> = {};
+    let materializationMetricsAggregate: Record<string, unknown> | null = null;
+    let totalRecordsProcessed = 0;
+
+    const handleConnectorResult = async (
+      connectorResult: Awaited<ReturnType<typeof connector.pullProducts>>
+    ): Promise<boolean> => {
+      connectorMetadata = { ...connectorMetadata, ...connectorResult.metadata };
+      totalRecordsProcessed += connectorResult.records.length;
+
+      logger.info(`Connector returned ${connectorResult.records.length} records`, connectorResult.metadata);
+
+      // Upsert external products
+      stage = "upsert_external_products";
+      logger.updateBaseMetrics(withPipelineMetrics(requestedMetrics, "running", stage, {
+        queuedAt: payload.queuedAt,
+        ...connectorMetadata,
+      }));
+      logger.info(`Upserting ${connectorResult.records.length} external products`);
+
+      const persistenceMetrics = await upsertExternalProducts(source.dataSourceId, connectorResult.records);
+      mergeMetrics(persistenceMetricsAggregate, persistenceMetrics as unknown as Record<string, unknown>);
+      logger.info(`Upsert complete`, persistenceMetrics as unknown as Record<string, unknown>);
+
+      let materializationMetrics: Record<string, unknown> | null = null;
+
+      if (payload.request.source === "MakeupAPI" && payload.request.materializeToInventory) {
+        stage = "materialize_inventory";
+        logger.updateBaseMetrics(withPipelineMetrics(requestedMetrics, "running", stage, {
+          queuedAt: payload.queuedAt,
+          ...connectorMetadata,
+          ...persistenceMetricsAggregate,
+        }));
+
+        const materializeStartTime = Date.now();
+        logger.info(`Materializing MakeupAPI records to inventory`, {
+          recordCount: connectorResult.records.length,
+          userId: payload.userId,
+        });
+
+        try {
+          materializationMetrics = (await materializeMakeupApiRecords(
+            payload.userId,
+            connectorResult.records
+          )) as unknown as Record<string, unknown>;
+
+          const materializeDuration = Date.now() - materializeStartTime;
+          logger.info(`MakeupAPI materialization complete`, {
+            ...materializationMetrics,
+            durationMs: materializeDuration,
+            recordsProcessed: connectorResult.records.length,
+          });
+        } catch (materializeError) {
+          const materializeDuration = Date.now() - materializeStartTime;
+          logger.error(`MakeupAPI materialization failed`, {
+            error: getErrorMessage(materializeError),
+            durationMs: materializeDuration,
+            recordCount: connectorResult.records.length,
+          });
+          throw materializeError;
+        }
+      }
+
+      if (payload.request.source.endsWith("Shopify") && payload.request.materializeToInventory) {
+        stage = "materialize_inventory";
+        logger.updateBaseMetrics(withPipelineMetrics(requestedMetrics, "running", stage, {
+          queuedAt: payload.queuedAt,
+          ...connectorMetadata,
+          ...persistenceMetricsAggregate,
+        }));
+
+        const materializeStartTime = Date.now();
+        logger.info(`Materializing ${payload.request.source} records to inventory`, {
+          recordCount: connectorResult.records.length,
+          userId: payload.userId,
+          dataSourceId: source.dataSourceId,
+          detectHexFromImage: payload.request.detectHexFromImage,
+          overwriteDetectedHex: payload.request.overwriteDetectedHex,
+          hexBatchEnabled: hexBatchConfig.enabled,
+          hexBatchMinImages: hexBatchConfig.minImages,
+        });
+
+        try {
+          materializationMetrics = (await materializeHoloTacoRecords(
+            payload.userId,
+            source.dataSourceId,
+            connectorResult.records,
+            {
+              detectHexFromImage: payload.request.detectHexFromImage,
+              detectHexOnSuspiciousOnly: payload.request.detectHexOnSuspiciousOnly,
+              overwriteDetectedHex: payload.request.overwriteDetectedHex,
+              useBatchForHexDetection: hexBatchConfig.enabled,
+              batchMinImages: hexBatchConfig.minImages,
+              progressLogger: {
+                info: (message, data) => logger.info(message, data),
+                warn: (message, data) => logger.warn(message, data),
+                error: (message, data) => logger.error(message, data),
+              },
+            },
+            `[${payload.request.source}]`
+          )) as unknown as Record<string, unknown>;
+
+          const materializeDuration = Date.now() - materializeStartTime;
+          logger.info(`${payload.request.source} materialization complete`, {
+            ...materializationMetrics,
+            durationMs: materializeDuration,
+            recordsProcessed: connectorResult.records.length,
+          });
+        } catch (materializeError) {
+          const materializeDuration = Date.now() - materializeStartTime;
+          logger.error(`${payload.request.source} materialization failed`, {
+            error: getErrorMessage(materializeError),
+            durationMs: materializeDuration,
+            recordCount: connectorResult.records.length,
+            detectHexFromImage: payload.request.detectHexFromImage,
+            overwriteDetectedHex: payload.request.overwriteDetectedHex,
+          });
+          throw materializeError;
+        }
+      }
+
+      materializationMetricsAggregate = mergeMetrics(
+        materializationMetricsAggregate ?? {},
+        materializationMetrics
+      );
+
+      const aiBatch =
+        materializationMetrics &&
+        typeof materializationMetrics === "object" &&
+        materializationMetrics.aiBatch &&
+        typeof materializationMetrics.aiBatch === "object"
+          ? (materializationMetrics.aiBatch as Record<string, unknown>)
+          : null;
+
+      if (aiBatch && aiBatch.status === "submitted" && typeof aiBatch.batchId === "string") {
+        stage = "awaiting_ai";
+        const awaitingAiMetrics = {
+          ...requestedMetrics,
+          ...connectorMetadata,
+          ...persistenceMetricsAggregate,
+          ...(materializationMetricsAggregate || {}),
+          recordsProcessed: totalRecordsProcessed,
+        };
+
+        logger.updateBaseMetrics(
+          withPipelineMetrics(awaitingAiMetrics, "running", stage, {
+            queuedAt: payload.queuedAt,
+            workerPausedAt: new Date().toISOString(),
+            aiBatch,
+          })
+        );
+        logger.info(`Job ${payload.jobId} awaiting Azure OpenAI batch completion`, {
+          batchId: aiBatch.batchId,
+          requestCount: aiBatch.requestCount,
+        });
+
+        await updateIngestionJobMetrics(payload.jobId, logger.getMetricsWithLogs());
+        await logger.dispose();
+        return true;
+      }
+
+      return false;
+    };
 
     if (payload.request.exhaustive) {
-      // Exhaustive mode: loop through all pages until empty
+      // Exhaustive mode: loop through all pages and process each page incrementally.
       let currentPage = payload.request.page;
-      const allRecords: (typeof connectorResult)["records"] = [];
-      let lastMetadata: Record<string, unknown> = {};
       let pagesFetched = 0;
 
       logger.info(`Exhaustive mode: paging through all records from ${payload.request.source}`, {
@@ -441,186 +622,55 @@ export async function processIngestionJobQueueMessage(
           recentDays: payload.request.recentDays,
         });
 
-        logger.info(
-          `Exhaustive page ${currentPage}: ${pageResult.records.length} records`,
-          { page: currentPage, ...pageResult.metadata }
-        );
+        logger.info(`Exhaustive page ${currentPage}: ${pageResult.records.length} records`, {
+          page: currentPage,
+          ...pageResult.metadata,
+        });
 
-        allRecords.push(...pageResult.records);
-        lastMetadata = { ...pageResult.metadata };
         pagesFetched++;
+        connectorMetadata = {
+          ...connectorMetadata,
+          ...pageResult.metadata,
+          pagesFetched,
+          exhaustive: true,
+        };
 
         if (pageResult.records.length === 0) {
           break;
         }
+
+        const awaitingAi = await handleConnectorResult(pageResult);
+        if (awaitingAi) {
+          return;
+        }
+
         currentPage++;
       }
 
-      connectorResult = { records: allRecords, source: payload.request.source, metadata: { ...lastMetadata, pagesFetched, exhaustive: true } };
-      logger.info(`Exhaustive pull complete: ${allRecords.length} total records across ${pagesFetched} pages`);
+      logger.info(`Exhaustive pull complete: ${totalRecordsProcessed} total records across ${pagesFetched} pages`);
     } else {
-      connectorResult = await connector.pullProducts({
+      const connectorResult = await connector.pullProducts({
         searchTerm: payload.request.searchTerm,
         page: payload.request.page,
         pageSize: payload.request.pageSize,
         maxRecords: payload.request.maxRecords,
         recentDays: payload.request.recentDays,
       });
-    }
 
-    logger.info(`Connector returned ${connectorResult.records.length} records`, connectorResult.metadata);
-
-    // Upsert external products
-    stage = "upsert_external_products";
-    logger.updateBaseMetrics(withPipelineMetrics(requestedMetrics, "running", stage, {
-      queuedAt: payload.queuedAt,
-      ...connectorResult.metadata,
-    }));
-    logger.info(`Upserting ${connectorResult.records.length} external products`);
-
-    const persistenceMetrics = await upsertExternalProducts(
-      source.dataSourceId,
-      connectorResult.records
-    );
-    logger.info(`Upsert complete`, persistenceMetrics as unknown as Record<string, unknown>);
-
-    let materializationMetrics: Record<string, unknown> | null = null;
-
-    if (payload.request.source === "MakeupAPI" && payload.request.materializeToInventory) {
-      stage = "materialize_inventory";
-      logger.updateBaseMetrics(withPipelineMetrics(requestedMetrics, "running", stage, {
-        queuedAt: payload.queuedAt,
-        ...connectorResult.metadata,
-        ...persistenceMetrics,
-      }));
-
-      const materializeStartTime = Date.now();
-      logger.info(`Materializing MakeupAPI records to inventory`, {
-        recordCount: connectorResult.records.length,
-        userId: payload.userId,
-      });
-
-      try {
-        materializationMetrics = (await materializeMakeupApiRecords(
-          payload.userId,
-          connectorResult.records
-        )) as unknown as Record<string, unknown>;
-
-        const materializeDuration = Date.now() - materializeStartTime;
-        logger.info(`MakeupAPI materialization complete`, {
-          ...materializationMetrics,
-          durationMs: materializeDuration,
-          recordsProcessed: connectorResult.records.length,
-        });
-      } catch (materializeError) {
-        const materializeDuration = Date.now() - materializeStartTime;
-        logger.error(`MakeupAPI materialization failed`, {
-          error: getErrorMessage(materializeError),
-          durationMs: materializeDuration,
-          recordCount: connectorResult.records.length,
-        });
-        throw materializeError;
+      connectorMetadata = { ...connectorMetadata, ...connectorResult.metadata };
+      const awaitingAi = await handleConnectorResult(connectorResult);
+      if (awaitingAi) {
+        return;
       }
-    }
-
-    if (payload.request.source.endsWith("Shopify") && payload.request.materializeToInventory) {
-      stage = "materialize_inventory";
-      logger.updateBaseMetrics(withPipelineMetrics(requestedMetrics, "running", stage, {
-        queuedAt: payload.queuedAt,
-        ...connectorResult.metadata,
-        ...persistenceMetrics,
-      }));
-
-      const materializeStartTime = Date.now();
-        logger.info(`Materializing ${payload.request.source} records to inventory`, {
-          recordCount: connectorResult.records.length,
-          userId: payload.userId,
-          dataSourceId: source.dataSourceId,
-          detectHexFromImage: payload.request.detectHexFromImage,
-          overwriteDetectedHex: payload.request.overwriteDetectedHex,
-          hexBatchEnabled: hexBatchConfig.enabled,
-          hexBatchMinImages: hexBatchConfig.minImages,
-        });
-
-        try {
-          materializationMetrics = (await materializeHoloTacoRecords(
-          payload.userId,
-          source.dataSourceId,
-          connectorResult.records,
-          {
-            detectHexFromImage: payload.request.detectHexFromImage,
-            detectHexOnSuspiciousOnly: payload.request.detectHexOnSuspiciousOnly,
-            overwriteDetectedHex: payload.request.overwriteDetectedHex,
-            useBatchForHexDetection: hexBatchConfig.enabled,
-            batchMinImages: hexBatchConfig.minImages,
-            progressLogger: {
-              info: (message, data) => logger.info(message, data),
-              warn: (message, data) => logger.warn(message, data),
-              error: (message, data) => logger.error(message, data),
-            },
-          },
-          `[${payload.request.source}]`
-        )) as unknown as Record<string, unknown>;
-
-        const materializeDuration = Date.now() - materializeStartTime;
-        logger.info(`${payload.request.source} materialization complete`, {
-          ...materializationMetrics,
-          durationMs: materializeDuration,
-          recordsProcessed: connectorResult.records.length,
-        });
-      } catch (materializeError) {
-        const materializeDuration = Date.now() - materializeStartTime;
-        logger.error(`${payload.request.source} materialization failed`, {
-          error: getErrorMessage(materializeError),
-          durationMs: materializeDuration,
-          recordCount: connectorResult.records.length,
-          detectHexFromImage: payload.request.detectHexFromImage,
-          overwriteDetectedHex: payload.request.overwriteDetectedHex,
-        });
-        throw materializeError;
-      }
-    }
-
-    const aiBatch =
-      materializationMetrics &&
-      typeof materializationMetrics === "object" &&
-      materializationMetrics.aiBatch &&
-      typeof materializationMetrics.aiBatch === "object"
-        ? (materializationMetrics.aiBatch as Record<string, unknown>)
-        : null;
-
-    if (aiBatch && aiBatch.status === "submitted" && typeof aiBatch.batchId === "string") {
-      stage = "awaiting_ai";
-      const awaitingAiMetrics = {
-        ...requestedMetrics,
-        ...connectorResult.metadata,
-        ...persistenceMetrics,
-        ...(materializationMetrics || {}),
-      };
-
-      logger.updateBaseMetrics(
-        withPipelineMetrics(awaitingAiMetrics, "running", stage, {
-          queuedAt: payload.queuedAt,
-          workerPausedAt: new Date().toISOString(),
-          aiBatch,
-        })
-      );
-      logger.info(`Job ${payload.jobId} awaiting Azure OpenAI batch completion`, {
-        batchId: aiBatch.batchId,
-        requestCount: aiBatch.requestCount,
-      });
-
-      await updateIngestionJobMetrics(payload.jobId, logger.getMetricsWithLogs());
-      await logger.dispose();
-      return;
     }
 
     // Build final metrics with logs
     const baseMetrics = {
       ...requestedMetrics,
-      ...connectorResult.metadata,
-      ...persistenceMetrics,
-      ...(materializationMetrics || {}),
+      ...connectorMetadata,
+      ...persistenceMetricsAggregate,
+      ...(materializationMetricsAggregate || {}),
+      recordsProcessed: totalRecordsProcessed,
     };
     logger.updateBaseMetrics(withPipelineMetrics(baseMetrics, "succeeded", "completed", {
       queuedAt: payload.queuedAt,

--- a/packages/functions/src/lib/connectors/generated-types.ts
+++ b/packages/functions/src/lib/connectors/generated-types.ts
@@ -3,6 +3,8 @@
  * Do not edit manually - run "npm run generate:types" to regenerate
  */
 
+import type { ConnectorProtocol } from "swatchwatch-shared";
+
 export type SupportedConnectorSource =
   | "BeesKneesLacquerShopify"
   | "ChinaGlazeShopify"
@@ -40,6 +42,45 @@ export type SupportedConnectorSource =
   | "ZombieClawPolishShopify"
   | "openFDA_CosmeticEvents";
 
+/** Maps each connector source to its protocol group for UI grouping and bulk selection. */
+export const SOURCE_PROTOCOL_MAP: Record<SupportedConnectorSource, ConnectorProtocol> = {
+  BeesKneesLacquerShopify: "Shopify",
+  ChinaGlazeShopify: "Shopify",
+  ClionadhShopify: "Shopify",
+  ColorClubShopify: "Shopify",
+  CosIng: "GS1",
+  CrackedPolishShopify: "Shopify",
+  CupcakePolishShopify: "Shopify",
+  DrunkFairyPolishShopify: "Shopify",
+  GS1Lookup: "GS1",
+  GardenPathLacquersShopify: "Shopify",
+  GreatLakesLacquerShopify: "Shopify",
+  HoloTacoShopify: "HoloTaco",
+  ImpactAffiliateNetwork: "Custom",
+  KathleenAndCoShopify: "Shopify",
+  LeMiniMacaronShopify: "Shopify",
+  LightsLacquerShopify: "Shopify",
+  LoudBabbsShopify: "Shopify",
+  MakeupAPI: "MakeupAPI",
+  MooncatShopify: "Shopify",
+  OliveAvePolishShopify: "Shopify",
+  OpenBeautyFacts: "OpenBeautyFacts",
+  OrlyShopify: "Shopify",
+  PaintItPrettyPolishShopify: "Shopify",
+  PotionPolishShopify: "Shopify",
+  PrismParadeShopify: "Shopify",
+  RakutenAdvertising: "Custom",
+  RedEyedLacquerShopify: "Shopify",
+  RogueLacquerShopify: "Shopify",
+  RoylaleeShopify: "Shopify",
+  SassysaucePolishShopify: "Shopify",
+  StarrilyShopify: "Shopify",
+  TylerStrinketsShopify: "Shopify",
+  UserCapture: "Custom",
+  ZombieClawPolishShopify: "Shopify",
+  openFDA_CosmeticEvents: "Custom",
+};
+
 // Runtime array for validation - same values as the type above
 export const SUPPORTED_SOURCES: SupportedConnectorSource[] = [
   "BeesKneesLacquerShopify",
@@ -76,4 +117,5 @@ export const SUPPORTED_SOURCES: SupportedConnectorSource[] = [
   "TylerStrinketsShopify",
   "UserCapture",
   "ZombieClawPolishShopify",
-  "openFDA_CosmeticEvents",];
+  "openFDA_CosmeticEvents",
+];

--- a/packages/functions/src/lib/connectors/generated-types.ts
+++ b/packages/functions/src/lib/connectors/generated-types.ts
@@ -40,47 +40,6 @@ export type SupportedConnectorSource =
   | "ZombieClawPolishShopify"
   | "openFDA_CosmeticEvents";
 
-import { ConnectorProtocol } from "swatchwatch-shared";
-
-/** Maps each connector source to its protocol group for UI grouping and bulk selection. */
-export const SOURCE_PROTOCOL_MAP: Record<SupportedConnectorSource, ConnectorProtocol> = {
-  BeesKneesLacquerShopify: "Shopify",
-  ChinaGlazeShopify: "Shopify",
-  ClionadhShopify: "Shopify",
-  ColorClubShopify: "Shopify",
-  CrackedPolishShopify: "Shopify",
-  CupcakePolishShopify: "Shopify",
-  DrunkFairyPolishShopify: "Shopify",
-  GardenPathLacquersShopify: "Shopify",
-  GreatLakesLacquerShopify: "Shopify",
-  HoloTacoShopify: "Shopify",
-  KathleenAndCoShopify: "Shopify",
-  LeMiniMacaronShopify: "Shopify",
-  LightsLacquerShopify: "Shopify",
-  LoudBabbsShopify: "Shopify",
-  MooncatShopify: "Shopify",
-  OliveAvePolishShopify: "Shopify",
-  OrlyShopify: "Shopify",
-  PaintItPrettyPolishShopify: "Shopify",
-  PotionPolishShopify: "Shopify",
-  PrismParadeShopify: "Shopify",
-  RedEyedLacquerShopify: "Shopify",
-  RogueLacquerShopify: "Shopify",
-  RoylaleeShopify: "Shopify",
-  SassysaucePolishShopify: "Shopify",
-  StarrilyShopify: "Shopify",
-  TylerStrinketsShopify: "Shopify",
-  ZombieClawPolishShopify: "Shopify",
-  OpenBeautyFacts: "OpenBeautyFacts",
-  MakeupAPI: "MakeupAPI",
-  CosIng: "GS1",
-  GS1Lookup: "GS1",
-  ImpactAffiliateNetwork: "Custom",
-  RakutenAdvertising: "Custom",
-  UserCapture: "Custom",
-  openFDA_CosmeticEvents: "Custom",
-};
-
 // Runtime array for validation - same values as the type above
 export const SUPPORTED_SOURCES: SupportedConnectorSource[] = [
   "BeesKneesLacquerShopify",

--- a/packages/functions/src/lib/connectors/generated-types.ts
+++ b/packages/functions/src/lib/connectors/generated-types.ts
@@ -40,6 +40,47 @@ export type SupportedConnectorSource =
   | "ZombieClawPolishShopify"
   | "openFDA_CosmeticEvents";
 
+import { ConnectorProtocol } from "swatchwatch-shared";
+
+/** Maps each connector source to its protocol group for UI grouping and bulk selection. */
+export const SOURCE_PROTOCOL_MAP: Record<SupportedConnectorSource, ConnectorProtocol> = {
+  BeesKneesLacquerShopify: "Shopify",
+  ChinaGlazeShopify: "Shopify",
+  ClionadhShopify: "Shopify",
+  ColorClubShopify: "Shopify",
+  CrackedPolishShopify: "Shopify",
+  CupcakePolishShopify: "Shopify",
+  DrunkFairyPolishShopify: "Shopify",
+  GardenPathLacquersShopify: "Shopify",
+  GreatLakesLacquerShopify: "Shopify",
+  HoloTacoShopify: "Shopify",
+  KathleenAndCoShopify: "Shopify",
+  LeMiniMacaronShopify: "Shopify",
+  LightsLacquerShopify: "Shopify",
+  LoudBabbsShopify: "Shopify",
+  MooncatShopify: "Shopify",
+  OliveAvePolishShopify: "Shopify",
+  OrlyShopify: "Shopify",
+  PaintItPrettyPolishShopify: "Shopify",
+  PotionPolishShopify: "Shopify",
+  PrismParadeShopify: "Shopify",
+  RedEyedLacquerShopify: "Shopify",
+  RogueLacquerShopify: "Shopify",
+  RoylaleeShopify: "Shopify",
+  SassysaucePolishShopify: "Shopify",
+  StarrilyShopify: "Shopify",
+  TylerStrinketsShopify: "Shopify",
+  ZombieClawPolishShopify: "Shopify",
+  OpenBeautyFacts: "OpenBeautyFacts",
+  MakeupAPI: "MakeupAPI",
+  CosIng: "GS1",
+  GS1Lookup: "GS1",
+  ImpactAffiliateNetwork: "Custom",
+  RakutenAdvertising: "Custom",
+  UserCapture: "Custom",
+  openFDA_CosmeticEvents: "Custom",
+};
+
 // Runtime array for validation - same values as the type above
 export const SUPPORTED_SOURCES: SupportedConnectorSource[] = [
   "BeesKneesLacquerShopify",

--- a/packages/functions/src/lib/connectors/types.ts
+++ b/packages/functions/src/lib/connectors/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated from docs/seed_data_sources.sql
 // Do not edit manually - run "node scripts/generate-connector-types.mjs" to regenerate
 import type { SupportedConnectorSource } from "./generated-types";
-import { SUPPORTED_SOURCES } from "./generated-types";
+import { SOURCE_PROTOCOL_MAP, SUPPORTED_SOURCES } from "./generated-types";
 
 export type { SupportedConnectorSource };
-export { SUPPORTED_SOURCES };
+export { SOURCE_PROTOCOL_MAP, SUPPORTED_SOURCES };
 
 export interface ConnectorPullOptions {
   searchTerm: string;

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -84,8 +84,11 @@ The package is automatically linked via npm workspaces — no publishing require
 | Type | Description |
 |------|-------------|
 | `IngestionSourceName` | Allowed source names for connector ingestion jobs (OpenBeautyFacts, MakeupAPI, HoloTacoShopify, CosIng, etc.) |
+| `ConnectorProtocol` | Connector protocol group: `"Shopify" \| "OpenBeautyFacts" \| "MakeupAPI" \| "GS1" \| "Custom"` |
 | `IngestionJobStatus` | Job lifecycle status: `queued \| running \| succeeded \| failed \| cancelled` |
-| `IngestionJobRunRequest` | Request payload for `POST /api/ingestion/jobs` (includes optional `recentDays`, `materializeToInventory`, `detectHexFromImage`, and `overwriteDetectedHex`) |
+| `IngestionJobRunRequest` | Request payload for `POST /api/ingestion/jobs` (includes optional `recentDays`, `materializeToInventory`, `detectHexFromImage`, `overwriteDetectedHex`, and `exhaustive` for full-catalog pulls) |
+| `BulkIngestionRequest` | Request payload for `POST /api/ingestion/bulk` (`sources: string[]`, optional `options` for materialize/hex detection) |
+| `BulkIngestionResponse` | Bulk run response: `{ enqueued: number, jobs: IngestionJobRecord[] }` |
 | `IngestionJobRecord` | Ingestion job summary payload (source, status, timestamps, metrics, error) |
 | `IngestionJobRunResponse` | Job-trigger response wrapper: `{ job }` |
 | `IngestionJobListResponse` | Job list payload: `{ jobs, total }` |

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -83,11 +83,11 @@ The package is automatically linked via npm workspaces — no publishing require
 
 | Type | Description |
 |------|-------------|
-| `IngestionSourceName` | Allowed source names for connector ingestion jobs (OpenBeautyFacts, MakeupAPI, HoloTacoShopify, CosIng, etc.) |
-| `ConnectorProtocol` | Connector protocol group: `"Shopify" \| "OpenBeautyFacts" \| "MakeupAPI" \| "GS1" \| "Custom"` |
+| `IngestionSourceName` | Allowed generated source names for connector ingestion jobs (OpenBeautyFacts, MakeupAPI, HoloTacoShopify, Shopify sources, CosIng, etc.) |
+| `ConnectorProtocol` | Connector protocol group: `"HoloTaco" \| "Shopify" \| "OpenBeautyFacts" \| "MakeupAPI" \| "GS1" \| "Custom"` |
 | `IngestionJobStatus` | Job lifecycle status: `queued \| running \| succeeded \| failed \| cancelled` |
 | `IngestionJobRunRequest` | Request payload for `POST /api/ingestion/jobs` (includes optional `recentDays`, `materializeToInventory`, `detectHexFromImage`, `overwriteDetectedHex`, and `exhaustive` for full-catalog pulls) |
-| `BulkIngestionRequest` | Request payload for `POST /api/ingestion/bulk` (`sources: string[]`, optional `options` for materialize/hex detection) |
+| `BulkIngestionRequest` | Request payload for `POST /api/ingestion/bulk` (`sources: IngestionSourceName[]`, optional `options` for `materializeToInventory`, `detectHexFromImage`, and `overwriteDetectedHex`) |
 | `BulkIngestionResponse` | Bulk run response: `{ enqueued: number, jobs: IngestionJobRecord[] }` |
 | `IngestionJobRecord` | Ingestion job summary payload (source, status, timestamps, metrics, error) |
 | `IngestionJobRunResponse` | Job-trigger response wrapper: `{ job }` |

--- a/packages/shared/src/types/ingestion.ts
+++ b/packages/shared/src/types/ingestion.ts
@@ -8,6 +8,13 @@ export type IngestionSourceName =
   | "ManualEntry"
   | "UserCapture";
 
+export type ConnectorProtocol =
+  | "Shopify"
+  | "OpenBeautyFacts"
+  | "MakeupAPI"
+  | "GS1"
+  | "Custom";
+
 export type IngestionJobStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled";
 
 export type IngestionLogLevel = "debug" | "info" | "warn" | "error";
@@ -35,6 +42,22 @@ export interface IngestionJobRunRequest {
   collectTrainingData?: boolean;
   /** When true and collectTrainingData=true, download images to blob storage. When false, just store vendor URLs (default: false) */
   downloadTrainingImages?: boolean;
+  /** When true, loop through all pages until source returns empty (ignores maxRecords cap) */
+  exhaustive?: boolean;
+}
+
+export interface BulkIngestionRequest {
+  sources: string[];
+  options?: {
+    materializeToInventory?: boolean;
+    detectHexFromImage?: boolean;
+    overwriteDetectedHex?: boolean;
+  };
+}
+
+export interface BulkIngestionResponse {
+  enqueued: number;
+  jobs: IngestionJobRecord[];
 }
 
 export interface IngestionJobRecord {

--- a/packages/shared/src/types/ingestion.ts
+++ b/packages/shared/src/types/ingestion.ts
@@ -1,14 +1,42 @@
 export type IngestionSourceName =
-  | "OpenBeautyFacts"
-  | "MakeupAPI"
-  | "HoloTacoShopify"
+  | "BeesKneesLacquerShopify"
+  | "ChinaGlazeShopify"
+  | "ClionadhShopify"
+  | "ColorClubShopify"
   | "CosIng"
+  | "CrackedPolishShopify"
+  | "CupcakePolishShopify"
+  | "DrunkFairyPolishShopify"
+  | "GS1Lookup"
+  | "GardenPathLacquersShopify"
+  | "GreatLakesLacquerShopify"
+  | "HoloTacoShopify"
   | "ImpactAffiliateNetwork"
+  | "KathleenAndCoShopify"
+  | "LeMiniMacaronShopify"
+  | "LightsLacquerShopify"
+  | "LoudBabbsShopify"
+  | "MakeupAPI"
+  | "MooncatShopify"
+  | "OliveAvePolishShopify"
+  | "OpenBeautyFacts"
+  | "OrlyShopify"
+  | "PaintItPrettyPolishShopify"
+  | "PotionPolishShopify"
+  | "PrismParadeShopify"
   | "RakutenAdvertising"
-  | "ManualEntry"
-  | "UserCapture";
+  | "RedEyedLacquerShopify"
+  | "RogueLacquerShopify"
+  | "RoylaleeShopify"
+  | "SassysaucePolishShopify"
+  | "StarrilyShopify"
+  | "TylerStrinketsShopify"
+  | "UserCapture"
+  | "ZombieClawPolishShopify"
+  | "openFDA_CosmeticEvents";
 
 export type ConnectorProtocol =
+  | "HoloTaco"
   | "Shopify"
   | "OpenBeautyFacts"
   | "MakeupAPI"
@@ -47,7 +75,7 @@ export interface IngestionJobRunRequest {
 }
 
 export interface BulkIngestionRequest {
-  sources: string[];
+  sources: IngestionSourceName[];
   options?: {
     materializeToInventory?: boolean;
     detectHexFromImage?: boolean;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "module": "commonjs",
     "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src/**/*"]
 }

--- a/scripts/generate-connector-types.mjs
+++ b/scripts/generate-connector-types.mjs
@@ -40,18 +40,45 @@ while ((match = sourcePattern.exec(sql)) !== null) {
 // Sort for deterministic output
 const sortedSources = Array.from(sources).sort();
 
+function protocolForSource(source) {
+  if (source === "HoloTacoShopify") {
+    return "HoloTaco";
+  }
+  if (source.endsWith("Shopify")) {
+    return "Shopify";
+  }
+  if (source === "OpenBeautyFacts") {
+    return "OpenBeautyFacts";
+  }
+  if (source === "MakeupAPI") {
+    return "MakeupAPI";
+  }
+  if (source === "CosIng" || source === "GS1Lookup") {
+    return "GS1";
+  }
+  return "Custom";
+}
+
 // Generate TypeScript - both type and runtime array
 const typeContent = `/**
  * Auto-generated from docs/seed_data_sources.sql
  * Do not edit manually - run "npm run generate:types" to regenerate
  */
 
+import type { ConnectorProtocol } from "swatchwatch-shared";
+
 export type SupportedConnectorSource =
 ${sortedSources.map((s) => `  | "${s}"`).join("\n")};
 
+/** Maps each connector source to its protocol group for UI grouping and bulk selection. */
+export const SOURCE_PROTOCOL_MAP: Record<SupportedConnectorSource, ConnectorProtocol> = {
+${sortedSources.map((s) => `  ${s}: "${protocolForSource(s)}",`).join("\n")}
+};
+
 // Runtime array for validation - same values as the type above
 export const SUPPORTED_SOURCES: SupportedConnectorSource[] = [
-${sortedSources.map((s) => `  "${s}",`).join("\n")}];
+${sortedSources.map((s) => `  "${s}",`).join("\n")}
+];
 `;
 
 // Write the generated file


### PR DESCRIPTION
## Summary

- Adds `POST /api/ingestion/bulk` — admin endpoint that enqueues exhaustive full-catalog jobs for multiple sources in a single request
- Adds **exhaustive paging mode** to the ingestion worker: loops `connector.pullProducts()` page-by-page until an empty page is returned (500-page safety cap), bypassing the normal `maxRecords` cap
- Adds `BulkRunCard` to the Admin Jobs tab: sources grouped by protocol (Shopify / OpenBeautyFacts / MakeupAPI), select-all per group, shared options (materialize, detect hex, overwrite hex), and a single "Run Bulk" button
- Adds `ConnectorProtocol`, `BulkIngestionRequest`, `BulkIngestionResponse` to `swatchwatch-shared`
- Adds `SOURCE_PROTOCOL_MAP` to `generated-types.ts` mapping all 36 connector sources to their protocol group

## Test plan

- [ ] Build passes: `npm run build:functions` and `npm run build:web` — ✅ verified locally
- [ ] Verify `POST /api/ingestion/bulk` accepts `{ sources: ["HoloTacoShopify", "MooncatShopify"], options: { materializeToInventory: true } }` and returns `{ enqueued: 2, jobs: [...] }`
- [ ] Verify each enqueued job runs exhaustively (loops pages until empty)
- [ ] Verify admin UI shows grouped source picker, select-all works per group and globally
- [ ] Verify invalid/unsupported sources in `sources[]` return 400 with descriptive error

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin: new bulk-ingestion card to select multiple sources, group by protocol, toggle options (materialize, AI hex detect, overwrite), and run bulk jobs with progress/error feedback.
  * API: new bulk ingestion endpoint that enqueues one ingestion job per selected source.
  * Ingestion: added an "exhaustive" full-catalog mode to iterate pages until completion and aggregate metrics.

* **Documentation**
  * Shared docs/types updated for bulk request/response, connector protocol groups, and the exhaustive flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->