### PR TITLE
chore(ci): wire HEX_DETECTION_BATCH_ENABLED through deploy-infra workflow

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -75,6 +75,7 @@ jobs:
       TF_VAR_openai_batch_model_version: ${{ vars.OPENAI_BATCH_MODEL_VERSION || '' }}
       TF_VAR_openai_batch_deployment_sku_name: ${{ vars.OPENAI_BATCH_DEPLOYMENT_SKU_NAME || 'GlobalBatch' }}
       TF_VAR_openai_batch_deployment_capacity: ${{ vars.OPENAI_BATCH_DEPLOYMENT_CAPACITY || '100' }}
+      TF_VAR_hex_detection_batch_enabled: ${{ vars.HEX_DETECTION_BATCH_ENABLED || 'false' }}
       OPENAI_ACCOUNT_NAME: ${{ vars.OPENAI_ACCOUNT_NAME || '' }}
       TF_VAR_apim_enabled: ${{ vars.APIM_ENABLED || 'false' }}
       # vars first, then literal default


### PR DESCRIPTION
## Summary

- Adds \`TF_VAR_hex_detection_batch_enabled\` to the \`deploy-infra.yml\` env block, sourced from GitHub Actions variable \`HEX_DETECTION_BATCH_ENABLED\` (defaults to \`'false'\`)
- The Terraform variable already exists ([\`infrastructure/variables.tf:240\`](infrastructure/variables.tf:240)) and maps to the Function App's \`HEX_DETECTION_BATCH_ENABLED\` app setting ([\`infrastructure/main.tf:466\`](infrastructure/main.tf:466)), but was never wired through CI — so any manual portal/CLI change to the app setting would be reverted on the next infra apply
- No behavior change unless someone sets the GitHub Actions variable

## Why

To enable Azure OpenAI Batch API for ingestion hex detection (currently runs synchronously, ~3–5 min for a 100-record source). Once this is merged and deployed:

1. Set repo/environment variable \`HEX_DETECTION_BATCH_ENABLED=true\` on the \`dev\` environment in GitHub Actions
2. Re-run Deploy Infra Dev
3. New ingestion jobs with ≥5 candidate images will submit to Batch instead of running synchronously

## Test plan

- [ ] Merge to \`dev\`
- [ ] In GitHub repo settings → Environments → dev → Variables, add \`HEX_DETECTION_BATCH_ENABLED=true\`
- [ ] Manually trigger Deploy Infra Dev
- [ ] Confirm \`az functionapp config appsettings list ... --query \"[?name=='HEX_DETECTION_BATCH_ENABLED']\"\` returns \`true\`
- [ ] Trigger a Shopify bulk ingestion and confirm logs show \`useBatchForHexDetection: true\` and \`Submitted Azure OpenAI batch <id>\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update includes infrastructure modifications to deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->