### PR TITLE
fix(web): make HarmonyPalette swatches keyboard accessible

### DIFF
--- a/apps/web/src/components/harmony-palette.tsx
+++ b/apps/web/src/components/harmony-palette.tsx
@@ -36,17 +36,21 @@ export function HarmonyPalette({
         </div>
         <div className="flex h-8 overflow-hidden rounded-lg border border-border">
           {targetColors.map((hex, i) => (
-            <div
+            <button
+              type="button"
               key={i}
-              className={`flex-1 cursor-pointer transition-all ${
+              className={`flex-1 cursor-pointer border-0 p-0 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset ${
                 focusedTargetHex === hex
                   ? "ring-2 ring-white ring-inset opacity-90 z-10"
                   : "hover:opacity-80"
               }`}
               style={{ backgroundColor: hex }}
               title={i === 0 ? `Source: ${hex}` : `Harmony ${i}: ${hex}`}
+              aria-label={i === 0 ? `Source color: ${hex}` : `Harmony color ${i}: ${hex}`}
               onMouseEnter={() => onSwatchHover?.(hex)}
               onMouseLeave={onSwatchLeave}
+              onFocus={() => onSwatchHover?.(hex)}
+              onBlur={onSwatchLeave}
               onClick={() => onSwatchClick?.(hex)}
             />
           ))}
@@ -60,31 +64,36 @@ export function HarmonyPalette({
           <div className="flex h-8 overflow-hidden rounded-lg border border-border">
             {targetColors.map((_, i) => {
               const matchHex = matchColors[i] ?? null;
+              if (!matchHex) {
+                return (
+                  <div
+                    key={i}
+                    className="flex-1"
+                    style={{
+                      backgroundImage:
+                        "repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(128,128,128,0.15) 4px, rgba(128,128,128,0.15) 8px)",
+                    }}
+                    title={`No match in ${matchLabel.toLowerCase()}`}
+                  />
+                );
+              }
               return (
-                <div
+                <button
+                  type="button"
                   key={i}
-                  className={`flex-1 ${
-                    matchHex
-                      ? `cursor-pointer transition-all ${
-                          focusedTargetHex === matchHex
-                            ? "ring-2 ring-white ring-inset opacity-90 z-10"
-                            : "hover:opacity-80"
-                        }`
-                      : ""
+                  className={`flex-1 cursor-pointer border-0 p-0 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset ${
+                    focusedTargetHex === matchHex
+                      ? "ring-2 ring-white ring-inset opacity-90 z-10"
+                      : "hover:opacity-80"
                   }`}
-                  style={{
-                    backgroundColor: matchHex ?? undefined,
-                    backgroundImage: matchHex
-                      ? undefined
-                      : "repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(128,128,128,0.15) 4px, rgba(128,128,128,0.15) 8px)",
-                  }}
-                  title={matchHex ? `Closest in ${matchLabel}: ${matchHex}` : `No match in ${matchLabel.toLowerCase()}`}
-                  onMouseEnter={() => matchHex && onSwatchHover?.(matchHex)}
+                  style={{ backgroundColor: matchHex }}
+                  title={`Closest in ${matchLabel}: ${matchHex}`}
+                  aria-label={`Closest match in ${matchLabel}: ${matchHex}`}
+                  onMouseEnter={() => onSwatchHover?.(matchHex)}
                   onMouseLeave={onSwatchLeave}
-                  onClick={() => {
-                    if (!matchHex) return;
-                    onSwatchClick?.(matchHex);
-                  }}
+                  onFocus={() => onSwatchHover?.(matchHex)}
+                  onBlur={onSwatchLeave}
+                  onClick={() => onSwatchClick?.(matchHex)}
                 />
               );
             })}


### PR DESCRIPTION
Closes #113

## Problem
`HarmonyPalette` rendered color swatches as `<div>` elements with `onClick`/`onMouseEnter`/`onMouseLeave` handlers. These were not keyboard-focusable and exposed no ARIA roles, so keyboard-only and screen-reader users could not interact with them (WCAG 2.1.1 Keyboard, Level A — Critical).

## Fix
- Convert interactive swatches (target bar + matched scope swatches) from `<div>` to `<button type="button">`.
- Add `aria-label` describing each swatch (source / harmony index / closest match).
- Add `onFocus`/`onBlur` handlers mirroring the existing `onMouseEnter`/`onMouseLeave` hover behavior, so keyboard focus drives the same preview highlight.
- Add `focus-visible` ring styling plus button resets (`border-0 p-0`) to preserve the existing flex layout.
- Keep the "no match" placeholder swatch as a non-interactive `<div>` (no action to perform).

## Testing
- `apps/web` test suite passes (31/31).
- Manual: Tab through swatches on `/polishes/search`, focus ring visible, Enter/Space activates the click handler, screen reader announces the color label.

> Note: the repo-wide pre-commit `npm test` has 6 pre-existing failures in `packages/devtools` (a Node ESM `require()`-cycle issue loading `next.config.ts`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Color palette interface now supports keyboard navigation with visual focus indicators.
  * Added accessibility labels to color swatches for improved screen reader support.

* **Bug Fixes**
  * Refined nail polish product detection for more accurate product categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->