### PR TITLE
feat(functions): synchronous fallback for batch hex submission + batch parsing tests

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -170,6 +170,9 @@ When `HEX_DETECTION_BATCH_ENABLED=true`, Shopify image detection can switch to A
 for larger runs (`HEX_DETECTION_BATCH_MIN_IMAGES` threshold). In that mode, the main worker submits
 the batch and leaves the job in `running` with pipeline stage `awaiting_ai`; a timer-triggered poller
 (`ingestion-ai-batch-poller`) later applies completed batch results and marks the job `succeeded`/`failed`.
+If batch submission itself fails, the worker logs the reason and falls back to synchronous detection for
+that run (applying detections through the same shade write path the poller uses), recording the count in
+the `batchFallbacks` metric instead of failing the job.
 Batch and sync image detection now send URL inputs to Azure OpenAI (instead of base64 payloads) using
 the Functions image proxy route (`/api/images/{id}`) when storage is configured.
 The proxy origin is resolved from `INGESTION_AI_IMAGE_PROXY_ORIGIN` or falls back to

--- a/packages/functions/src/lib/ingestion-repo.ts
+++ b/packages/functions/src/lib/ingestion-repo.ts
@@ -125,6 +125,7 @@ interface HoloTacoImagePreparationMetrics {
   hexDetectionFailures: number;
   hexDetectionSkipped: number;
   batchRequestsQueued: number;
+  batchFallbacks: number;
   hexDetectionPromptTokens: number;
   hexDetectionCompletionTokens: number;
   hexDetectionTotalTokens: number;
@@ -333,6 +334,7 @@ function estimateBatchCandidateCount(
 
 async function prepareHoloTacoImageData(
   records: ConnectorProductRecord[],
+  dataSourceId: number,
   options?: HoloTacoMaterializationOptions,
   sourceLogPrefix: string = "[HoloTaco]",
   onRecordPrepared?: (
@@ -368,6 +370,7 @@ async function prepareHoloTacoImageData(
     hexDetectionFailures: 0,
     hexDetectionSkipped: 0,
     batchRequestsQueued: 0,
+    batchFallbacks: 0,
     hexDetectionPromptTokens: 0,
     hexDetectionCompletionTokens: 0,
     hexDetectionTotalTokens: 0,
@@ -673,18 +676,79 @@ async function prepareHoloTacoImageData(
 
   let aiBatch: HoloTacoAiBatchDetails | null = null;
   if (useBatchForHexDetection && queuedBatchRequests.length > 0) {
-    const batchResult = await submitVisionHexBatch(queuedBatchRequests);
-    aiBatch = {
-      batchId: batchResult.batchId,
-      inputFileId: batchResult.inputFileId,
-      requestCount: batchResult.requestCount,
-      submittedAt: batchResult.submittedAt,
-      status: "submitted",
-      overwriteDetectedHex: options?.overwriteDetectedHex === true,
-    };
-    const submittedMessage = `${sourceLogPrefix} Submitted Azure OpenAI batch ${batchResult.batchId} with ${batchResult.requestCount} request(s)`;
-    console.log(submittedMessage);
-    progressLogger?.info(submittedMessage, aiBatch as unknown as Record<string, unknown>);
+    try {
+      const batchResult = await submitVisionHexBatch(queuedBatchRequests);
+      aiBatch = {
+        batchId: batchResult.batchId,
+        inputFileId: batchResult.inputFileId,
+        requestCount: batchResult.requestCount,
+        submittedAt: batchResult.submittedAt,
+        status: "submitted",
+        overwriteDetectedHex: options?.overwriteDetectedHex === true,
+      };
+      const submittedMessage = `${sourceLogPrefix} Submitted Azure OpenAI batch ${batchResult.batchId} with ${batchResult.requestCount} request(s)`;
+      console.log(submittedMessage);
+      progressLogger?.info(submittedMessage, aiBatch as unknown as Record<string, unknown>);
+    } catch (error) {
+      // Batch submission failed: degrade to synchronous detection for this run so the
+      // job still materializes detected hex instead of failing outright. Detections are
+      // applied via the same shade write path the batch poller uses.
+      const reason = error instanceof Error ? error.message : String(error);
+      metrics.batchFallbacks += 1;
+      const fallbackMessage = `${sourceLogPrefix} Batch submission failed (${reason}); falling back to synchronous hex detection for ${queuedBatchRequests.length} request(s)`;
+      console.warn(fallbackMessage);
+      progressLogger?.warn(fallbackMessage, {
+        reason,
+        requestCount: queuedBatchRequests.length,
+      });
+
+      const fallbackDetections: AiBatchShadeDetectionInput[] = [];
+      for (const queued of queuedBatchRequests) {
+        try {
+          const detection = await detectHexWithAzureOpenAI(queued.imageUrlOrDataUri, {
+            vendorContext: queued.vendorContext,
+            onLog: (level, message, data) => {
+              const withRecord = `${sourceLogPrefix} ${queued.customId} ${message}`;
+              if (level === "error") {
+                progressLogger?.error(withRecord, data);
+              } else if (level === "warn") {
+                progressLogger?.warn(withRecord, data);
+              } else {
+                progressLogger?.info(withRecord, data);
+              }
+            },
+          });
+          metrics.hexDetectionPromptTokens += detection.usage?.promptTokens ?? 0;
+          metrics.hexDetectionCompletionTokens += detection.usage?.completionTokens ?? 0;
+          metrics.hexDetectionTotalTokens += detection.usage?.totalTokens ?? 0;
+          if (detection.hex) {
+            metrics.hexDetected += 1;
+            fallbackDetections.push({
+              externalId: queued.customId,
+              detectedHex: detection.hex,
+              detectedFinishes: detection.finishes,
+            });
+          }
+        } catch (detectionError) {
+          metrics.hexDetectionFailures += 1;
+          console.error(
+            `${sourceLogPrefix} Fallback AI hex detection failed for ${queued.customId}:`,
+            String(detectionError)
+          );
+        }
+      }
+
+      if (fallbackDetections.length > 0) {
+        const applyMetrics = await applyAiBatchShadeDetections(
+          dataSourceId,
+          fallbackDetections,
+          options?.overwriteDetectedHex === true
+        );
+        const appliedMessage = `${sourceLogPrefix} Applied ${applyMetrics.applied} synchronous fallback detection(s)`;
+        console.log(appliedMessage, applyMetrics);
+        progressLogger?.info(appliedMessage, applyMetrics as unknown as Record<string, unknown>);
+      }
+    }
   }
 
   return {
@@ -1863,6 +1927,7 @@ export async function materializeHoloTacoRecords(
 
   const preparedImageData = await prepareHoloTacoImageData(
     records,
+    dataSourceId,
     options,
     sourceLogPrefix,
     async (record, preparedImage) => {

--- a/packages/functions/tests/azure-openai-batch.unit.test.cjs
+++ b/packages/functions/tests/azure-openai-batch.unit.test.cjs
@@ -3,11 +3,249 @@ const assert = require("node:assert/strict");
 
 const {
   parseVisionHexBatchOutput,
+  parseVisionHexBatchDetections,
   getVisionHexBatchStatus,
   submitVisionHexBatch,
 } = require("../dist/lib/azure-openai-batch");
 
-// ... keep parseVisionHexBatchOutput describe block as-is ...
+// Builds a single successful Azure OpenAI batch output line (chat-completions shape).
+function successLine(customId, content, usage) {
+  return JSON.stringify({
+    custom_id: customId,
+    response: {
+      status_code: 200,
+      body: {
+        choices: [{ message: { content } }],
+        ...(usage ? { usage } : {}),
+      },
+    },
+  });
+}
+
+describe("lib/azure-openai-batch — parseVisionHexBatchOutput", () => {
+  it("maps custom_id to content, status code, and token usage", () => {
+    const jsonl = [
+      successLine('ext-1', '{"hex":"#aabbcc","confidence":0.9}', {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      }),
+    ].join("\n");
+
+    const rows = parseVisionHexBatchOutput(jsonl);
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].customId, "ext-1");
+    assert.equal(rows[0].statusCode, 200);
+    assert.equal(rows[0].content, '{"hex":"#aabbcc","confidence":0.9}');
+    assert.equal(rows[0].error, null);
+    assert.equal(rows[0].usage.totalTokens, 15);
+  });
+
+  it("skips malformed JSON, blank lines, and rows without a custom_id", () => {
+    const jsonl = [
+      "",
+      "   ",
+      "{ this is not json",
+      JSON.stringify({ response: { status_code: 200, body: {} } }), // no custom_id
+      successLine("ext-keep", '{"hex":"#112233"}'),
+    ].join("\n");
+
+    const rows = parseVisionHexBatchOutput(jsonl);
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].customId, "ext-keep");
+  });
+
+  it("captures error rows with null content and preserves the error message", () => {
+    const jsonl = [
+      successLine("ext-ok", '{"hex":"#00ff00"}'),
+      JSON.stringify({
+        custom_id: "ext-bad",
+        response: { status_code: 500, body: {} },
+        error: { message: "internal failure", code: "server_error" },
+      }),
+    ].join("\n");
+
+    const rows = parseVisionHexBatchOutput(jsonl);
+
+    assert.equal(rows.length, 2);
+    const bad = rows.find((r) => r.customId === "ext-bad");
+    assert.equal(bad.content, null);
+    assert.equal(bad.statusCode, 500);
+    assert.equal(bad.error, "internal failure");
+  });
+
+  it("returns an empty array for empty input", () => {
+    assert.deepEqual(parseVisionHexBatchOutput(""), []);
+  });
+});
+
+describe("lib/azure-openai-batch — parseVisionHexBatchDetections", () => {
+  it("maps successful rows back to their custom_id with a parsed hex", async () => {
+    const rows = parseVisionHexBatchOutput(
+      successLine("ext-1", '{"hex":"#AABBCC","confidence":0.8}')
+    );
+
+    const detections = await parseVisionHexBatchDetections(rows);
+
+    assert.equal(detections.length, 1);
+    assert.equal(detections[0].customId, "ext-1");
+    assert.equal(detections[0].detection.hex, "#AABBCC");
+    assert.equal(detections[0].error, null);
+  });
+
+  it("handles a batch with partial failures: success keeps detection, failure surfaces error", async () => {
+    const jsonl = [
+      successLine("ext-good", '{"hex":"#123456","confidence":0.7}'),
+      JSON.stringify({
+        custom_id: "ext-fail",
+        response: { status_code: 500, body: {} },
+        error: { message: "boom" },
+      }),
+    ].join("\n");
+
+    const detections = await parseVisionHexBatchDetections(
+      parseVisionHexBatchOutput(jsonl)
+    );
+
+    const good = detections.find((d) => d.customId === "ext-good");
+    const fail = detections.find((d) => d.customId === "ext-fail");
+
+    assert.equal(good.detection.hex, "#123456");
+    assert.equal(good.error, null);
+    assert.equal(fail.detection, null);
+    assert.equal(fail.error, "boom");
+  });
+
+  it("reports missing completion content as an error with no detection", async () => {
+    const rows = parseVisionHexBatchOutput(
+      JSON.stringify({
+        custom_id: "ext-empty",
+        response: { status_code: 200, body: { choices: [] } },
+      })
+    );
+
+    const detections = await parseVisionHexBatchDetections(rows);
+
+    assert.equal(detections.length, 1);
+    assert.equal(detections[0].detection, null);
+    assert.match(detections[0].error, /Missing completion content/);
+  });
+});
+
+describe("lib/azure-openai-batch — submitVisionHexBatch JSONL generation", () => {
+  const ENV_KEYS = [
+    "AZURE_OPENAI_USE_GATEWAY",
+    "AZURE_OPENAI_GATEWAY_ENDPOINT",
+    "AZURE_OPENAI_GATEWAY_SUBSCRIPTION_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_OPENAI_KEY",
+    "AZURE_OPENAI_DEPLOYMENT_HEX",
+    "AZURE_OPENAI_DEPLOYMENT",
+    "AZURE_OPENAI_DEPLOYMENT_HEX_BATCH",
+  ];
+  let savedEnv;
+  let savedFetch;
+
+  beforeEach(() => {
+    savedEnv = {};
+    savedFetch = global.fetch;
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.AZURE_OPENAI_ENDPOINT = "https://direct.openai.azure.com/";
+    process.env.AZURE_OPENAI_KEY = "direct-api-key";
+    process.env.AZURE_OPENAI_DEPLOYMENT_HEX = "gpt4o-deploy";
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    global.fetch = savedFetch;
+  });
+
+  it("uploads one JSONL line per request with the chat-completions request contract", async () => {
+    let uploadedJsonl;
+    let createBody;
+
+    global.fetch = async (url, init) => {
+      if (url.includes("/openai/files")) {
+        const file = init.body.get("file");
+        uploadedJsonl = await file.text();
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ id: "file-123" })),
+        };
+      }
+      if (url.includes("/openai/batches")) {
+        createBody = JSON.parse(init.body);
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ id: "batch-xyz" })),
+        };
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    };
+
+    const result = await submitVisionHexBatch([
+      {
+        customId: "ext-1",
+        imageUrlOrDataUri: "https://img.example.com/a.jpg",
+        vendorContext: { shadeName: "Mint Chip" },
+      },
+      {
+        customId: "ext-2",
+        imageUrlOrDataUri: "https://img.example.com/b.jpg",
+      },
+    ]);
+
+    assert.deepEqual(
+      { batchId: result.batchId, inputFileId: result.inputFileId, requestCount: result.requestCount },
+      { batchId: "batch-xyz", inputFileId: "file-123", requestCount: 2 }
+    );
+    assert.equal(createBody.input_file_id, "file-123");
+    assert.equal(createBody.endpoint, "/chat/completions");
+
+    const lines = uploadedJsonl.split("\n").filter((line) => line.trim().length > 0);
+    assert.equal(lines.length, 2);
+
+    const first = JSON.parse(lines[0]);
+    assert.equal(first.custom_id, "ext-1");
+    assert.equal(first.method, "POST");
+    assert.equal(first.url, "/chat/completions");
+    assert.equal(first.body.model, "gpt4o-deploy");
+    assert.ok(Array.isArray(first.body.messages));
+
+    // The image reference is passed as a URL (not uploaded bytes).
+    const userContent = first.body.messages[first.body.messages.length - 1].content;
+    const imagePart = userContent.find((part) => part.type === "image_url");
+    assert.equal(imagePart.image_url.url, "https://img.example.com/a.jpg");
+
+    // Vendor context is included for the request that supplied it.
+    const vendorPart = userContent.find(
+      (part) => part.type === "text" && part.text.startsWith("Vendor context:")
+    );
+    assert.ok(vendorPart, "expected vendor context text part for ext-1");
+    assert.match(vendorPart.text, /Mint Chip/);
+
+    // The second request omitted vendor context.
+    const second = JSON.parse(lines[1]);
+    assert.equal(second.custom_id, "ext-2");
+    const secondVendorPart = second.body.messages[
+      second.body.messages.length - 1
+    ].content.find((part) => part.type === "text" && part.text.startsWith("Vendor context:"));
+    assert.equal(secondVendorPart, undefined);
+  });
+});
 
 describe("lib/azure-openai-batch — getBatchConfig gateway/direct matrix", () => {
   // Saved env vars restored after each test to avoid cross-test pollution.


### PR DESCRIPTION
## Summary
Hardens the Azure OpenAI Batch API hex-detection path (issue #148) so a batch submission failure degrades gracefully instead of failing the ingestion job, and restores the batch output-parsing test coverage.

- When batch submission fails, the ingestion worker logs the reason and **falls back to synchronous hex detection** for that run, applying results through the same shade write path the poller uses (tracked via a new `batchFallbacks` metric).
- Adds/restores unit coverage:
  - `parseVisionHexBatchOutput` — custom_id mapping, malformed/error rows, usage accounting
  - `parseVisionHexBatchDetections` — success + partial-failure mapping
  - `submitVisionHexBatch` — JSONL generation (URL inputs, request contract)

## Verification
- `tsc --noEmit` (functions) ✅
- `node --test azure-openai-batch.unit.test.cjs` — 12/12 ✅
- Full functions suite — 186/186 ✅

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)