### PR TITLE
fix(devtools): load next.config.ts via tsx tsImport to avoid require(esm) cycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18212,7 +18212,10 @@
     },
     "packages/devtools": {
       "name": "swatchwatch-devtools",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devDependencies": {
+        "tsx": "^4.21.0"
+      }
     },
     "packages/functions": {
       "name": "swatchwatch-functions",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "scripts": {
     "test": "node --import tsx/esm --test tests/*.test.cjs"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
   }
 }

--- a/packages/devtools/tests/edge-cases.test.cjs
+++ b/packages/devtools/tests/edge-cases.test.cjs
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
+const { tsImport } = require('tsx/esm/api');
 
 const DETECT_CHANGES_PATH = path.resolve(__dirname, '../../../.husky/detect-changes.sh');
 
@@ -205,7 +206,9 @@ test('.env.example: handles edge case variable values', () => {
 // Regression tests
 test('next.config.ts: does not use deprecated target option', async () => {
   const configPath = path.resolve(__dirname, '../../../apps/web/next.config.ts');
-  const config = await import(configPath);
+  // Use tsx's programmatic loader instead of a bare `import()` to avoid Node's
+  // `require(esm)` cycle guard when loading a `.ts` file from this `.cjs` test.
+  const config = await tsImport(configPath, __filename);
   const nextConfig = config.default || config;
 
   assert.equal(

--- a/packages/devtools/tests/next-config.test.cjs
+++ b/packages/devtools/tests/next-config.test.cjs
@@ -1,15 +1,19 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const { tsImport } = require('tsx/esm/api');
 
 const NEXT_CONFIG_PATH = path.resolve(__dirname, '../../../apps/web/next.config.ts');
 
 // Dynamic import helper for ESM modules
 async function importNextConfig() {
-  // Use dynamic import to load the TypeScript/ESM config.
-  // tsx/esm wraps `export default` under an extra `.default` when loaded
-  // via dynamic import() from a CJS file — unwrap both layers defensively.
-  const mod = await import(NEXT_CONFIG_PATH);
+  // Load the TypeScript/ESM config via tsx's programmatic loader. A bare
+  // `import()` of a `.ts` file from this `.cjs` test trips Node's
+  // `require(esm)` cycle guard (Node 22+); `tsImport` performs the transpile
+  // and load out-of-band, avoiding the cycle.
+  // tsx wraps `export default` under an extra `.default` — unwrap both layers
+  // defensively.
+  const mod = await tsImport(NEXT_CONFIG_PATH, __filename);
   return mod.default?.default ?? mod.default ?? mod;
 }
 


### PR DESCRIPTION
## What

The devtools tests loaded the ESM/TS `next.config.ts` from `.cjs` test files with a bare `await import(...)`. Under Node 22's `require(esm)` support this trips the cycle guard:

> Cannot require() ES Module … in a cycle. A cycle involving require(esm) is not allowed…

…causing the `next.config.ts` assertions in `next-config.test.cjs` and `edge-cases.test.cjs` to fail, which forced an earlier commit to be pushed with `--no-verify`.

## Fix

- Load the config through tsx's programmatic loader (`tsImport` from `tsx/esm/api`), which transpiles and loads out-of-band and sidesteps the cycle.
- Declare `tsx` as an explicit `devDependency` of the devtools package (it was previously relied on via hoisting through the `node --import tsx/esm` test script).

## Verification

Full `npm test` (the pre-commit hook), all green:

- web 31/31 · devtools 140/140 · functions 193/193

The hook now passes without `--no-verify`. This was a latent bug that would fail in CI on any Node 22+ runner, not just one worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)