### PR TITLE
chore(infra): bump Azure Functions runtime to Node 22

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Smart nail polish collection manager. **npm workspaces monorepo** with three dep
 ```
 apps/web          → Next.js 16 (App Router) + Tailwind v4 + shadcn/ui → Azure Static Web App
 apps/mobile       → Expo / React Native (SDK 54, RN 0.81)
-packages/functions → Azure Functions v4 (Node 20, TS)    → Azure Linux Function App
+packages/functions → Azure Functions v4 (Node 22, TS)    → Azure Linux Function App
 packages/shared    → Shared TypeScript types (polish, user, voice)
 infrastructure/    → Terraform (azurerm ~3.100) for all Azure resources
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ apps/web          → Next.js 16 (App Router) + Tailwind v4 + shadcn/ui → Azur
 apps/mobile       → Expo / React Native (SDK 54, RN 0.81)
 packages/functions → Azure Functions v4 (Node 22, TS)    → Azure Linux Function App
 packages/shared    → Shared TypeScript types (polish, user, voice)
-infrastructure/    → Terraform (azurerm ~3.100) for all Azure resources
+infrastructure/    → Terraform (azurerm ~4.50) for all Azure resources
 ```
 
 **Data flow:** Clients → Azure Functions REST API (`/api/polishes`, `/api/auth/*`, `/api/voice`) → Azure Database for PostgreSQL Flexible Server (schema in `docs/schema.sql`). Voice input goes through Azure Speech Services → Azure OpenAI for parsing polish details from transcriptions. Full canonical schema uses `pg_trgm` for fuzzy shade matching and `pgvector` for swatch similarity/dupe search.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ swatchwatch/
 │   ├── web/              → Next.js 16 (App Router) + Tailwind v4 + shadcn/ui
 │   └── mobile/           → Expo / React Native (SDK 54)
 ├── packages/
-│   ├── functions/        → Azure Functions v4 (Node 20, TypeScript)
+│   ├── functions/        → Azure Functions v4 (Node 22, TypeScript)
 │   └── shared/           → Shared TypeScript types (polish, user, voice)
 └── infrastructure/       → Terraform (azurerm ~3.100)
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ swatchwatch/
 ├── packages/
 │   ├── functions/        → Azure Functions v4 (Node 22, TypeScript)
 │   └── shared/           → Shared TypeScript types (polish, user, voice)
-└── infrastructure/       → Terraform (azurerm ~3.100)
+└── infrastructure/       → Terraform (azurerm ~4.50)
 ```
 
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -100,7 +100,7 @@ In external OpenAI mode (`CREATE_OPENAI_RESOURCES=false`), the workflow resolves
 | Application Insights | `azurerm_application_insights.main` | Function telemetry, traces, requests, and exceptions |
 | API Management *(optional)* | `azurerm_api_management.main` | Azure API Management Consumption gateway for Azure OpenAI traffic (`apim_enabled=true`) |
 | App Service Plan | `azurerm_service_plan.main` | Linux Consumption plan (Y1) |
-| Function App | `azurerm_linux_function_app.main` | Node 20 function host (Managed Identity enabled) |
+| Function App | `azurerm_linux_function_app.main` | Node 22 function host (Managed Identity enabled) |
 | Static Web App | `azurerm_static_web_app.main` | Next.js frontend (Standard tier) |
 | Document Intelligence *(optional)* | `azurerm_cognitive_account.document_intelligence` | Server-side OCR for capture pipeline label/barcode extraction (`enable_document_intelligence=true`) |
 | Speech Services | `azurerm_cognitive_account.speech` | Speech-to-text for voice input |

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -430,7 +430,7 @@ resource "azurerm_linux_function_app" "main" {
     application_insights_key               = azurerm_application_insights.main.instrumentation_key
 
     application_stack {
-      node_version = "20"
+      node_version = "22"
     }
 
     cors {

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -1,6 +1,6 @@
 # Azure Functions — `packages/functions`
 
-Azure Functions v4 HTTP API (Node 20, TypeScript).
+Azure Functions v4 HTTP API (Node 22, TypeScript).
 
 ## Running Locally
 


### PR DESCRIPTION
Companion to the toolchain bump (#198). Moves the **Azure Functions runtime** off Node 20 (deprecated) to Node 22.

## Changes

- `infrastructure/main.tf` — `application_stack.node_version` `"20"` → `"22"`
- Docs — `Node 20` → `Node 22` in root `README.md`, `CLAUDE.md`, `packages/functions/README.md`, `infrastructure/README.md`

## Why Node 22 is safe

Node 22 is **GA** on Azure Functions v4 Linux with support through **2027-04-30** (verified against Microsoft Learn). Node 22 is also the last version supported on the Linux Consumption plan.

## Deploy note ⚠️

This changes the **live Function App runtime**, so it requires a `terraform apply` and the Function App **restarts** when the runtime version changes. Merge/apply this deliberately alongside a deploy window rather than letting it ride silently — that's why it's split from #198.

`terraform fmt -check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)