### PR TITLE
fix(devtools): load next.config.ts via plain import under tsx --test runner

### DIFF
--- a/packages/devtools/tests/edge-cases.test.cjs
+++ b/packages/devtools/tests/edge-cases.test.cjs
@@ -3,7 +3,6 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
-const { tsImport } = require('tsx/esm/api');
 
 const DETECT_CHANGES_PATH = path.resolve(__dirname, '../../../.husky/detect-changes.sh');
 
@@ -206,9 +205,9 @@ test('.env.example: handles edge case variable values', () => {
 // Regression tests
 test('next.config.ts: does not use deprecated target option', async () => {
   const configPath = path.resolve(__dirname, '../../../apps/web/next.config.ts');
-  // Use tsx's programmatic loader instead of a bare `import()` to avoid Node's
-  // `require(esm)` cycle guard when loading a `.ts` file from this `.cjs` test.
-  const config = await tsImport(configPath, __filename);
+  // Run under the `tsx --test` runner, which imports this .ts config cleanly
+  // without tripping Node's `require(esm)` cycle guard (Node 22+).
+  const config = await import(configPath);
   const nextConfig = config.default || config;
 
   assert.equal(

--- a/packages/devtools/tests/next-config.test.cjs
+++ b/packages/devtools/tests/next-config.test.cjs
@@ -1,19 +1,16 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
-const { tsImport } = require('tsx/esm/api');
 
 const NEXT_CONFIG_PATH = path.resolve(__dirname, '../../../apps/web/next.config.ts');
 
 // Dynamic import helper for ESM modules
 async function importNextConfig() {
-  // Load the TypeScript/ESM config via tsx's programmatic loader. A bare
-  // `import()` of a `.ts` file from this `.cjs` test trips Node's
-  // `require(esm)` cycle guard (Node 22+); `tsImport` performs the transpile
-  // and load out-of-band, avoiding the cycle.
-  // tsx wraps `export default` under an extra `.default` — unwrap both layers
-  // defensively.
-  const mod = await tsImport(NEXT_CONFIG_PATH, __filename);
+  // Run under the `tsx --test` runner (see package.json), whose loader
+  // transpiles and imports this .ts/ESM config without tripping Node's
+  // `require(esm)` cycle guard (Node 22+). tsx may wrap `export default`
+  // under an extra `.default` -- unwrap both layers defensively.
+  const mod = await import(NEXT_CONFIG_PATH);
   return mod.default?.default ?? mod.default ?? mod;
 }
 


### PR DESCRIPTION
## Problem

dev is **broken on Node 22+** after #198 and #199 merged in an order that left an incompatible combination:

- **#198** set the devtools test script to `tsx --test` and bumped `tsx` to `^4.22.4`
- **#199** changed the test files to load `next.config.ts` via `tsImport` from `tsx/esm/api`

Under tsx 4.22.4, `tsImport` emits a CJS-virtual module that references `__filename`, which is undefined in ESM scope:

```
ReferenceError: __filename is not defined in ES module scope
  at next.config.ts ... tsx-commonjs-virtual-query
```

Result: **4 `next.config.ts` tests fail** in `packages/devtools` on Node 22 (`136/140`). CI didn't catch it because `ci.yml` doesn't run the workspace test suite — these only run via the local husky hooks.

## Fix

The `tsx --test` runner (from #198) already transpiles and imports the `.ts`/ESM config cleanly, without the `require(esm)` cycle that motivated #199's `tsImport`. So `tsImport` is now both unnecessary and broken — revert both test files to a plain `await import()` and refresh the comments.

## Verification

Full workspace suite on Node 22.20.0, **0 failures**:
- shared 31/31, devtools **140/140**, web 193/193
- `typecheck` + `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)