### PR TITLE
fix(devtools): load next.config.ts via plain import in tsx --test runner

### DIFF
--- a/packages/devtools/tests/edge-cases.test.cjs
+++ b/packages/devtools/tests/edge-cases.test.cjs
@@ -2,7 +2,6 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
-const { pathToFileURL } = require('node:url');
 const { execFileSync } = require('node:child_process');
 
 const DETECT_CHANGES_PATH = path.resolve(__dirname, '../../../.husky/detect-changes.sh');
@@ -206,9 +205,9 @@ test('.env.example: handles edge case variable values', () => {
 // Regression tests
 test('next.config.ts: does not use deprecated target option', async () => {
   const configPath = path.resolve(__dirname, '../../../apps/web/next.config.ts');
-  // Use tsx's programmatic loader instead of a bare `import()` to avoid Node's
-  // `require(esm)` cycle guard when loading a `.ts` file from this `.cjs` test.
-  const config = await tsImport(configPath, pathToFileURL(__filename).href);
+  // Run under the `tsx --test` runner, whose loader transpiles and imports this
+  // .ts/ESM config without tripping Node's `require(esm)` cycle guard (Node 22+).
+  const config = await import(configPath);
   const nextConfig = config.default || config;
 
   assert.equal(

--- a/packages/devtools/tests/next-config.test.cjs
+++ b/packages/devtools/tests/next-config.test.cjs
@@ -6,9 +6,12 @@ const NEXT_CONFIG_PATH = path.resolve(__dirname, '../../../apps/web/next.config.
 
 // Dynamic import helper for ESM modules
 async function importNextConfig() {
-  // Load the TypeScript/ESM config via tsx's programmatic loader. A bare
-  // `import()` of a `.ts` file from this `.cjs` test trips Node's
-  const mod = await tsImport(NEXT_CONFIG_PATH, require('node:url').pathToFileURL(__filename).href);
+  // Run under the `tsx --test` runner (see package.json), whose loader
+  // transpiles and imports this .ts/ESM config without tripping Node's
+  // `require(esm)` cycle guard (Node 22+). tsx may wrap `export default`
+  // under an extra `.default` -- unwrap both layers defensively.
+  const mod = await import(NEXT_CONFIG_PATH);
+  return mod.default?.default ?? mod.default ?? mod;
 }
 
 test('next.config.ts: exports a valid Next.js configuration', async () => {


### PR DESCRIPTION
## Summary
The devtools test suite was red on `dev`: `next-config.test.cjs` and `edge-cases.test.cjs` called `tsImport(...)` which is never imported (`ReferenceError: tsImport is not defined`), and `importNextConfig()` had no `return`. PR #201 originally fixed this, but a later merge into `dev` reverted the files to the broken state.

Since the suite runs under the `tsx --test` runner (`package.json`: `tsx --test tests/*.test.cjs`), tsx transpiles the `.ts` config on import — so a plain dynamic `import()` works without tripping Node 22's `require(esm)` cycle guard. Removed the now-unused `pathToFileURL` import from `edge-cases.test.cjs`.

This unblocks CI/the full `npm run test` for every other branch.

## Verification
- `npm run test -w swatchwatch-devtools` → **140/140 pass, deterministic across 3 consecutive runs**, zero `tsImport`/`ERR_REQUIRE_CYCLE` errors.
- Full `npm run test` → web 31/31, devtools 140/140, functions 193/193, all green.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved devtools test infrastructure for enhanced test runner compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->