### PR TITLE
fix(web): add aria-label to icon-only pagination buttons

### DIFF
--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -64,9 +64,8 @@ export function Pagination({
           size="sm"
           disabled={currentPage <= 1}
           onClick={() => onPageChange(Math.max(1, currentPage - 5))}
-          aria-label="Back 5 pages"
-          title="Back 5 pages"
-        >
+          aria-label="Back up to 5 pages"
+          title="Back up to 5 pages"
           ‹‹
         </Button>
         <Button
@@ -106,9 +105,8 @@ export function Pagination({
           size="sm"
           disabled={currentPage >= totalPages}
           onClick={() => onPageChange(Math.min(totalPages, currentPage + 5))}
-          aria-label="Forward 5 pages"
-          title="Forward 5 pages"
-        >
+          aria-label="Forward up to 5 pages"
+          title="Forward up to 5 pages"
           ››
         </Button>
         <Button

--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -66,6 +66,7 @@ export function Pagination({
           onClick={() => onPageChange(Math.max(1, currentPage - 5))}
           aria-label="Back up to 5 pages"
           title="Back up to 5 pages"
+        >
           ‹‹
         </Button>
         <Button
@@ -107,6 +108,7 @@ export function Pagination({
           onClick={() => onPageChange(Math.min(totalPages, currentPage + 5))}
           aria-label="Forward up to 5 pages"
           title="Forward up to 5 pages"
+        >
           ››
         </Button>
         <Button

--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -54,6 +54,7 @@ export function Pagination({
           size="sm"
           disabled={currentPage <= 1}
           onClick={() => onPageChange(1)}
+          aria-label="First page"
           title="First page"
         >
           «
@@ -63,6 +64,7 @@ export function Pagination({
           size="sm"
           disabled={currentPage <= 1}
           onClick={() => onPageChange(Math.max(1, currentPage - 5))}
+          aria-label="Back 5 pages"
           title="Back 5 pages"
         >
           ‹‹
@@ -104,6 +106,7 @@ export function Pagination({
           size="sm"
           disabled={currentPage >= totalPages}
           onClick={() => onPageChange(Math.min(totalPages, currentPage + 5))}
+          aria-label="Forward 5 pages"
           title="Forward 5 pages"
         >
           ››
@@ -113,6 +116,7 @@ export function Pagination({
           size="sm"
           disabled={currentPage >= totalPages}
           onClick={() => onPageChange(totalPages)}
+          aria-label="Last page"
           title="Last page"
         >
           »


### PR DESCRIPTION
## Summary
Closes #122. The pagination First / Back-5 / Forward-5 / Last buttons render only glyph characters (`«`, `‹‹`, `››`, `»`) and relied on `title` for their accessible name — so screen readers announced the glyph, not the action. Added an `aria-label` to each (the `title` is kept for the sighted hover tooltip).

### Audit of the rest of #122
Swept all `title=` usages in `apps/web`. The remaining ones are **not** violations:
- Search-page action buttons (add/clear/remove focused color) already have `aria-label`.
- The "◎ Mine" toggle has visible text ("Mine").
- The polish-detail "Open image" link wraps an `<Image>` with descriptive `alt` (accessible name present).
- Other `title=` are tooltips on non-interactive elements (empty-states, swatch dots, table cells).

## Verification
- `npm run lint -w apps/web` → 0 errors (2 pre-existing unrelated warnings).
- `npm run test -w apps/web` → 31/31 pass.

> Note: CI's full `npm run test` needs PR #203 (fixes pre-existing #185 devtools test) merged first to be green; this change only touches `pagination.tsx`.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)