### PR TITLE
feat(functions): add Dam Nail Polish as a Shopify ingestion source

### DIFF
--- a/docs/seed_data_sources.sql
+++ b/docs/seed_data_sources.sql
@@ -61,6 +61,15 @@ VALUES
     '{"priority":"high","mvp":"yes","notes":"Mooncat Shopify store. Rich tags with color/finish metadata. Hex extraction from option values."}'::jsonb
   ),
   (
+    'DamNailPolishShopify',
+    'api',
+    'https://damnailpolish.com',
+    'Storefront terms apply (verify metadata/image usage obligations)',
+    NULL,
+    true,
+    '{"priority":"medium","mvp":"no","notes":"Dam Nail Polish Shopify store (vendor \"Dam Nail Polish\"). Indie polish + bundles; tags include finishes (Glitter, Shimmer). Uses generic Shopify connector."}'::jsonb
+  ),
+  (
     'ClionadhShopify',
     'api',
     'https://clionadhcosmetics.com',

--- a/packages/functions/src/lib/connectors/generated-types.ts
+++ b/packages/functions/src/lib/connectors/generated-types.ts
@@ -13,6 +13,7 @@ export type SupportedConnectorSource =
   | "CosIng"
   | "CrackedPolishShopify"
   | "CupcakePolishShopify"
+  | "DamNailPolishShopify"
   | "DrunkFairyPolishShopify"
   | "GS1Lookup"
   | "GardenPathLacquersShopify"
@@ -51,6 +52,7 @@ export const SOURCE_PROTOCOL_MAP: Record<SupportedConnectorSource, ConnectorProt
   CosIng: "GS1",
   CrackedPolishShopify: "Shopify",
   CupcakePolishShopify: "Shopify",
+  DamNailPolishShopify: "Shopify",
   DrunkFairyPolishShopify: "Shopify",
   GS1Lookup: "GS1",
   GardenPathLacquersShopify: "Shopify",
@@ -90,6 +92,7 @@ export const SUPPORTED_SOURCES: SupportedConnectorSource[] = [
   "CosIng",
   "CrackedPolishShopify",
   "CupcakePolishShopify",
+  "DamNailPolishShopify",
   "DrunkFairyPolishShopify",
   "GS1Lookup",
   "GardenPathLacquersShopify",

--- a/packages/functions/src/lib/connectors/shopify-generic.ts
+++ b/packages/functions/src/lib/connectors/shopify-generic.ts
@@ -715,6 +715,7 @@ export class ShopifyGenericConnector implements ProductConnector {
 // Shared map used by connector runtime and data_source auto-provisioning.
 export const SHOPIFY_SOURCE_BASE_URLS: Record<string, string> = {
   MooncatShopify: "https://www.mooncat.com",
+  DamNailPolishShopify: "https://damnailpolish.com",
   ClionadhShopify: "https://clionadhcosmetics.com",
   OrlyShopify: "https://orlybeauty.com",
   BeesKneesLacquerShopify: "https://www.beeskneeslacquer.com",


### PR DESCRIPTION
## Summary
Closes #101. Registers **damnailpolish.com** as `DamNailPolishShopify`, ingested via the existing generic Shopify connector (no new connector code).

Verified the store is Shopify: `GET https://damnailpolish.com/products.json` returns products with vendor `"Dam Nail Polish"` and finish tags (Glitter, Shimmer).

### Changes
- `docs/seed_data_sources.sql` — new `data_source` seed row (`DamNailPolishShopify`, `https://damnailpolish.com`).
- `packages/functions/src/lib/connectors/generated-types.ts` — regenerated via `scripts/generate-connector-types.mjs` (adds the source to `SupportedConnectorSource`, `SOURCE_PROTOCOL_MAP` → `Shopify`, and `SUPPORTED_SOURCES`).
- `packages/functions/src/lib/connectors/shopify-generic.ts` — base URL in `SHOPIFY_SOURCE_BASE_URLS` for runtime + auto-provisioning.

Ingestion itself is kicked off from the Admin Jobs UI after the source is seeded on deploy; this PR only defines the source (matches how prior Shopify sources were added).

## Verification
- `node scripts/generate-connector-types.mjs` → source present in all three generated structures.
- `npm run build:functions` → clean.
- `npm run test -w swatchwatch-functions` → 193/193 pass.

> Note: CI's full `npm run test` needs PR #203 (#185 devtools fix) merged first to be green.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)