### PR TITLE
feat(infra): re-add Azure Managed Redis as opt-in (disabled by default)

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -474,6 +474,10 @@ resource "azurerm_linux_function_app" "main" {
     AZURE_OPENAI_DEPLOYMENT_LABEL         = var.openai_label_deployment_name
     AUTH_DEV_BYPASS                       = var.auth_dev_bypass ? "true" : "false"
     CORS_ALLOWED_ORIGINS                  = join(",", local.function_cors_allowed_origins)
+    # Optional Redis read-through cache. Empty when create_redis = false; the app
+    # caching layer (lib/cache.ts) no-ops gracefully when these are unset.
+    REDIS_URL = var.create_redis ? "rediss://${azurerm_managed_redis.main[0].hostname}:10000" : ""
+    REDIS_KEY = var.create_redis ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.redis_key[0].versionless_id})" : ""
   }
 
   lifecycle {
@@ -541,6 +545,37 @@ resource "azurerm_key_vault_secret" "document_intelligence_key" {
     azurerm_key_vault_access_policy.deployer,
     azurerm_key_vault_access_policy.github_actions,
     azurerm_cognitive_account.document_intelligence,
+  ]
+}
+
+# ── Azure Managed Redis (optional) ─────────────────────────────
+# Disabled by default (create_redis = false). The API caching layer reads
+# REDIS_URL/REDIS_KEY and degrades gracefully when they are empty, so the app
+# runs identically with or without this. Set create_redis = true to provision
+# the cache and wire the connection settings into the Function App.
+
+resource "azurerm_managed_redis" "main" {
+  count               = var.create_redis ? 1 : 0
+  name                = "${local.resource_prefix}-redis-${local.unique_suffix}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku_name            = "Balanced_B0"
+
+  default_database {
+    access_keys_authentication_enabled = true
+  }
+}
+
+resource "azurerm_key_vault_secret" "redis_key" {
+  count        = var.create_redis ? 1 : 0
+  name         = "redis-key"
+  value        = azurerm_managed_redis.main[0].default_database[0].primary_access_key
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [
+    azurerm_key_vault_access_policy.deployer,
+    azurerm_key_vault_access_policy.github_actions,
+    azurerm_managed_redis.main,
   ]
 }
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -143,11 +143,11 @@ output "subscription_id" {
 
 output "redis_hostname" {
   description = "Azure Managed Redis hostname (empty when create_redis = false)"
-  value       = var.create_redis ? azurerm_managed_redis.main[0].hostname : ""
+  value       = try(azurerm_managed_redis.main[0].hostname, "")
 }
 
 output "redis_primary_access_key" {
   description = "Azure Managed Redis primary access key (empty when create_redis = false)"
-  value       = var.create_redis ? azurerm_managed_redis.main[0].default_database[0].primary_access_key : ""
+  value       = try(azurerm_managed_redis.main[0].default_database[0].primary_access_key, "")
   sensitive   = true
 }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -140,3 +140,14 @@ output "subscription_id" {
   description = "Azure subscription ID - add to GitHub Secrets as AZURE_SUBSCRIPTION_ID"
   value       = data.azurerm_client_config.current.subscription_id
 }
+
+output "redis_hostname" {
+  description = "Azure Managed Redis hostname (empty when create_redis = false)"
+  value       = var.create_redis ? azurerm_managed_redis.main[0].hostname : ""
+}
+
+output "redis_primary_access_key" {
+  description = "Azure Managed Redis primary access key (empty when create_redis = false)"
+  value       = var.create_redis ? azurerm_managed_redis.main[0].default_database[0].primary_access_key : ""
+  sensitive   = true
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -272,3 +272,9 @@ variable "ingestion_ai_batch_max_poll_jobs" {
   type        = number
   default     = 10
 }
+
+variable "create_redis" {
+  description = "Provision Azure Managed Redis and wire REDIS_URL/REDIS_KEY into the Function App. Disabled by default; the API caching layer (lib/cache.ts) degrades gracefully when these settings are empty. Set to true to enable read-through caching."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
Refs #117. Restores Azure Managed Redis to Terraform — but **disabled by default** — so the read-through cache can be enabled purely through configuration without reversing the earlier removal's intent (no resources are created unless you opt in).

The app caching layer (`packages/functions/src/lib/cache.ts`) already reads `REDIS_URL`/`REDIS_KEY` and no-ops gracefully when they're empty, so this is the only missing piece to make caching toggleable.

### Changes (mirrors the existing `enable_document_intelligence` count/`[0]` pattern)
- New `create_redis` variable (`bool`, default **`false`**).
- `azurerm_managed_redis.main` + `azurerm_key_vault_secret.redis_key`, both `count`-gated on `create_redis`.
- Function App `app_settings`: `REDIS_URL`/`REDIS_KEY` populated only when `create_redis = true`, empty otherwise.
- `redis_hostname` / `redis_primary_access_key` outputs (empty when disabled).

**To enable:** set `create_redis = true` (provisions the cache + wires the connection settings). Default deploys are unchanged and create nothing new.

## Verification
- `terraform fmt -check` → clean
- `terraform init -backend=false && terraform validate` → **"Success! The configuration is valid."**
- `terraform plan` not run here (needs Azure credentials/backend); with `create_redis=false` the plan is a no-op for Redis.

Refs #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)