### PR TITLE
chore(functions): dated filenames for new migrations (forward-only)

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -212,6 +212,14 @@ If a queue message is malformed but includes a valid `jobId`, the worker marks t
 
 Schema migrations use [node-pg-migrate](https://github.com/salsita/node-pg-migrate) with raw SQL files in `migrations/`. Each file contains an up migration and a `-- Down Migration` section for rollback.
 
+### Naming convention (dated filenames)
+
+**New migrations use a UTC timestamp prefix:** `YYYYMMDDHHMMSSsss_description.sql` — a 17-digit UTC datetime down to the millisecond, e.g. `20260608021420930_add-swatch-index.sql`. `npm run migrate:create -- "add swatch index"` generates this automatically (`--migration-filename-format utc`).
+
+Timestamp prefixes are monotonic and globally unique, which avoids the prefix collisions the old sequential `NNN_` scheme is prone to (this repo already has two `020_` files). They also sort *after* the legacy `0NN_` files lexicographically, so ordering is preserved.
+
+> **Existing `001_`–`022_` files are intentionally left as-is.** node-pg-migrate records applied migrations by filename in the `pgmigrations` table — renaming an already-applied migration would make it look unapplied and re-run it. Only new migrations adopt the dated format; the legacy files are migrated forward by convention, not by rename.
+
 ```bash
 # From repo root (requires DATABASE_URL or PG* env vars)
 npm run migrate          # Apply pending migrations

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc -w",
     "migrate": "node -e \"try{const s=require('./local.settings.json');Object.entries(s.Values).forEach(([k,v])=>process.env[k]=v)}catch{} require('child_process').execSync('node-pg-migrate up --migrations-dir migrations --decamelize',{stdio:'inherit'})\"",
     "migrate:down": "node -e \"try{const s=require('./local.settings.json');Object.entries(s.Values).forEach(([k,v])=>process.env[k]=v)}catch{} require('child_process').execSync('node-pg-migrate down --migrations-dir migrations --decamelize',{stdio:'inherit'})\"",
-    "migrate:create": "node-pg-migrate create --migrations-dir migrations"
+    "migrate:create": "node-pg-migrate create --migrations-dir migrations --migration-filename-format utc --migration-file-language sql"
   },
   "dependencies": {
     "@azure/functions": "^4.0.0",


### PR DESCRIPTION
## Summary (DRAFT — per request, nothing existing is touched)
Closes #55. Adopts UTC timestamp-prefixed filenames for **new** migrations, **forward-only** so nothing breaks.

- `migrate:create` now uses `--migration-filename-format utc --migration-file-language sql`, producing `YYYYMMDDHHMMSSsss_description.sql` (e.g. `20260608021420930_add-swatch-index.sql`).
- Documented the convention in `packages/functions/README.md`.

### Why forward-only (the safety bit)
node-pg-migrate records applied migrations **by filename** in the `pgmigrations` table. Renaming an already-applied `0NN_` file would make it look unapplied and **re-run** it — so the existing `001_`–`022_` files are deliberately left untouched. Timestamp prefixes also sort *after* `0NN_` lexicographically, so ordering is preserved, and they remove the collision risk the sequential scheme already hit (two `020_` files exist today).

## Verification
- `npm run migrate:create -- verify` generated `20260608021420930_verify-dated-convention.sql` (then removed); existing migrations unchanged.
- `package.json` validated as JSON.

Left as **draft** so you can confirm the forward-only approach (vs. a riskier full rename) before merging.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)