### PR TITLE
chore(functions): bind polishes rows to the shared Polish contract (#50)

### DIFF
--- a/packages/functions/src/functions/polishes.ts
+++ b/packages/functions/src/functions/polishes.ts
@@ -1,5 +1,5 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
-import { PolishCreateRequest, PolishUpdateRequest, PolishListResponse } from "swatchwatch-shared";
+import { Polish, PolishCreateRequest, PolishUpdateRequest, PolishListResponse } from "swatchwatch-shared";
 import { query, transaction } from "../lib/db";
 import { withAuth, withAdmin } from "../lib/auth";
 import { withCors } from "../lib/http";
@@ -312,7 +312,7 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
         return { status: 200, jsonBody: cachedPolish };
       }
 
-      const result = await query(
+      const result = await query<Polish>(
         `${POLISH_SELECT}
          WHERE s.shade_id = $2`,
         [userId, shadeId]
@@ -456,7 +456,7 @@ async function getPolishes(request: HttpRequest, context: InvocationContext, use
     const sortColumn = SORT_COLUMNS[sortBy] || SORT_COLUMNS.createdAt;
     const whereClause = conditions.length > 0 ? conditions.join(" AND ") : "TRUE";
 
-    const result = await query(
+    const result = await query<Polish>(
       `${POLISH_SELECT}
        WHERE ${whereClause}
        ORDER BY ${sortColumn} ${sortOrder} NULLS LAST
@@ -575,7 +575,7 @@ async function createPolish(request: HttpRequest, context: InvocationContext, us
       return { shadeId: resolvedShadeId };
     });
 
-    const created = await query(
+    const created = await query<Polish>(
       `${POLISH_SELECT}
        WHERE s.shade_id = $2`,
       [userId, shadeId]
@@ -685,7 +685,7 @@ async function updatePolish(request: HttpRequest, context: InvocationContext, us
       return targetShadeId;
     });
 
-    const fullResult = await query(
+    const fullResult = await query<Polish>(
       `${POLISH_SELECT}
        WHERE s.shade_id = $2`,
       [userId, updatedShadeId]


### PR DESCRIPTION
## Summary
Closes #50 under the **API-contract alignment** interpretation: shared types match what the Functions handlers actually return/accept (the HTTP wire shapes), verified by `tsc` — rather than mirroring every DB table (the shared types are a curated domain model, not a schema clone; see the issue discussion).

### The gap
The polishes handler imported `PolishCreateRequest`/`PolishUpdateRequest`/`PolishListResponse` but read its `POLISH_SELECT` rows **untyped**, so drift between the SQL projection and the shared `Polish` type was invisible to the compiler.

### The fix
Type the four `POLISH_SELECT` queries (detail, list, create, update) as `query<Polish>(...)`. Rows now flow as `Polish` into `withReadableSwatchUrl<Polish>` and into the `PolishListResponse` body, so `tsc` enforces the contract end-to-end. No runtime change — `POLISH_SELECT` already projects exactly the `Polish` fields.

### Audit of the other handlers (already aligned)
`catalog`, `reference`, `admin-reference`, `admin-users`, `capture`, and `ingestion` all already import and bind their shared `*Response`/`*Request` contracts. `polishes` was the outlier. `voice.ts` remains a stub (no contract to enforce yet).

## Verification
- `npm run build:functions` → clean (binding surfaced no drift)
- `npm run test -w swatchwatch-functions` → 193/193 pass

> Note: full-repo CI needs PR #203 (#185 fix) merged first.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)