### PR TITLE
feat(functions): dominant-color extraction from images (#105)

### DIFF
--- a/packages/functions/src/lib/dominant-color.ts
+++ b/packages/functions/src/lib/dominant-color.ts
@@ -1,0 +1,116 @@
+import sharp from "sharp";
+
+/**
+ * A dominant color extracted from an image, with the share of sampled pixels it
+ * represents. `hex` is an uppercase `#RRGGBB` string (the average color of the
+ * quantization bucket, which reads more naturally than a bucket corner).
+ */
+export interface DominantColor {
+  hex: string;
+  fraction: number;
+}
+
+export interface ExtractDominantColorsOptions {
+  /** Max colors to return, ordered by prominence. Default 5. */
+  maxColors?: number;
+  /** Longest-edge size the image is downscaled to before sampling. Default 64. */
+  sampleSize?: number;
+  /**
+   * Bits of precision kept per channel when bucketing similar colors together
+   * (1–8). Lower merges more aggressively. Default 4 (16 levels per channel).
+   */
+  quantizeBits?: number;
+  /** Pixels with alpha below this (0–255) are ignored. Default 16. */
+  ignoreAlphaBelow?: number;
+}
+
+const DEFAULTS = {
+  maxColors: 5,
+  sampleSize: 64,
+  quantizeBits: 4,
+  ignoreAlphaBelow: 16,
+} as const;
+
+function toHex(value: number): string {
+  return Math.max(0, Math.min(255, Math.round(value)))
+    .toString(16)
+    .padStart(2, "0")
+    .toUpperCase();
+}
+
+interface Bucket {
+  count: number;
+  rSum: number;
+  gSum: number;
+  bSum: number;
+}
+
+/**
+ * Extract the most prominent colors from a raster image.
+ *
+ * The image is downscaled, decoded to raw RGBA, and each opaque pixel is binned
+ * into a coarse color bucket; buckets are ranked by pixel count and the average
+ * color of each top bucket is returned. Pure with respect to its input buffer —
+ * the only dependency is sharp for decoding — which makes it straightforward to
+ * unit test and to call from an ingestion or capture handler.
+ *
+ * @param image Encoded image bytes (PNG/JPEG/WebP/etc.).
+ * @returns Dominant colors ordered most→least prominent (empty if no opaque pixels).
+ */
+export async function extractDominantColors(
+  image: Buffer,
+  options?: ExtractDominantColorsOptions
+): Promise<DominantColor[]> {
+  const maxColors = Math.max(1, options?.maxColors ?? DEFAULTS.maxColors);
+  const sampleSize = Math.max(1, options?.sampleSize ?? DEFAULTS.sampleSize);
+  const quantizeBits = Math.max(1, Math.min(8, options?.quantizeBits ?? DEFAULTS.quantizeBits));
+  const ignoreAlphaBelow = options?.ignoreAlphaBelow ?? DEFAULTS.ignoreAlphaBelow;
+  const shift = 8 - quantizeBits;
+
+  const { data, info } = await sharp(image)
+    .resize(sampleSize, sampleSize, { fit: "inside", withoutEnlargement: true })
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const channels = info.channels; // 4 after ensureAlpha
+  const buckets = new Map<number, Bucket>();
+  let opaquePixels = 0;
+
+  for (let i = 0; i + channels - 1 < data.length; i += channels) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const a = channels >= 4 ? data[i + 3] : 255;
+    if (a < ignoreAlphaBelow) {
+      continue;
+    }
+
+    // Bucket key packs the high bits of each channel into one integer.
+    const key = ((r >> shift) << 16) | ((g >> shift) << 8) | (b >> shift);
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.count += 1;
+      bucket.rSum += r;
+      bucket.gSum += g;
+      bucket.bSum += b;
+    } else {
+      buckets.set(key, { count: 1, rSum: r, gSum: g, bSum: b });
+    }
+    opaquePixels += 1;
+  }
+
+  if (opaquePixels === 0) {
+    return [];
+  }
+
+  return Array.from(buckets.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, maxColors)
+    .map((bucket) => ({
+      hex: `#${toHex(bucket.rSum / bucket.count)}${toHex(bucket.gSum / bucket.count)}${toHex(
+        bucket.bSum / bucket.count
+      )}`,
+      fraction: bucket.count / opaquePixels,
+    }));
+}

--- a/packages/functions/tests/dominant-color.unit.test.cjs
+++ b/packages/functions/tests/dominant-color.unit.test.cjs
@@ -1,0 +1,78 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const sharp = require("sharp");
+
+const { extractDominantColors } = require("../dist/lib/dominant-color");
+
+// Build a PNG from a raw RGBA buffer.
+function pngFromRgba(width, height, fill) {
+  const buf = Buffer.alloc(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b, a] = fill(x, y);
+      const i = (y * width + x) * 4;
+      buf[i] = r;
+      buf[i + 1] = g;
+      buf[i + 2] = b;
+      buf[i + 3] = a;
+    }
+  }
+  return sharp(buf, { raw: { width, height, channels: 4 } }).png().toBuffer();
+}
+
+describe("lib/dominant-color — extractDominantColors", () => {
+  it("returns the single color of a solid image", async () => {
+    const png = await pngFromRgba(32, 32, () => [255, 0, 0, 255]);
+    const colors = await extractDominantColors(png);
+
+    assert.equal(colors.length, 1);
+    assert.equal(colors[0].hex, "#FF0000");
+    assert.ok(colors[0].fraction > 0.99, `expected ~1.0, got ${colors[0].fraction}`);
+  });
+
+  it("returns two colors for a split image, each ~half", async () => {
+    const png = await pngFromRgba(40, 40, (x) =>
+      x < 20 ? [255, 0, 0, 255] : [0, 0, 255, 255]
+    );
+    const colors = await extractDominantColors(png, { maxColors: 5 });
+    const hexes = colors.map((c) => c.hex);
+
+    assert.ok(hexes.includes("#FF0000"), `missing red: ${hexes.join(",")}`);
+    assert.ok(hexes.includes("#0000FF"), `missing blue: ${hexes.join(",")}`);
+    for (const c of colors) {
+      assert.ok(c.fraction > 0.3 && c.fraction < 0.7, `unexpected fraction ${c.fraction}`);
+    }
+  });
+
+  it("orders colors by prominence (dominant first)", async () => {
+    // 75% green, 25% black
+    const png = await pngFromRgba(40, 40, (x) => (x < 30 ? [0, 200, 0, 255] : [0, 0, 0, 255]));
+    const colors = await extractDominantColors(png);
+
+    assert.ok(colors.length >= 2);
+    assert.equal(colors[0].hex, "#00C800");
+    assert.ok(colors[0].fraction > colors[1].fraction);
+  });
+
+  it("respects maxColors", async () => {
+    // Distinct color per column → many buckets.
+    const png = await pngFromRgba(30, 4, (x) => [x * 8, 255 - x * 8, (x * 4) % 256, 255]);
+    const colors = await extractDominantColors(png, { maxColors: 3 });
+
+    assert.ok(colors.length <= 3, `expected <= 3, got ${colors.length}`);
+  });
+
+  it("ignores transparent pixels and returns [] for a fully transparent image", async () => {
+    const png = await pngFromRgba(16, 16, () => [255, 0, 0, 0]);
+    const colors = await extractDominantColors(png);
+
+    assert.deepEqual(colors, []);
+  });
+
+  it("emits uppercase #RRGGBB hex strings", async () => {
+    const png = await pngFromRgba(16, 16, () => [171, 205, 239, 255]); // #ABCDEF
+    const [color] = await extractDominantColors(png);
+
+    assert.match(color.hex, /^#[0-9A-F]{6}$/);
+  });
+});


### PR DESCRIPTION
## Summary
Advances #105 (image-to-polish color matching) with its core building block: **`extractDominantColors(buffer)`** in `packages/functions/src/lib/dominant-color.ts`.

It decodes an image with `sharp` (already a dependency), downsamples, bins opaque pixels into coarse color buckets, and returns the most prominent colors as uppercase `#RRGGBB` plus each color's pixel-share `fraction`. Tunable `maxColors` / `sampleSize` / `quantizeBits` / `ignoreAlphaBelow`. Buffer-in / array-out — pure aside from sharp decoding, so it's easy to test and to call from a capture/ingestion handler.

### Why this shape
The web search page already matches a single hex against the catalog (OKLAB). Extraction was the missing piece: feed a photo → get candidate hexes → reuse the existing match-by-hex path.

## Verification
- `npm run build:functions` → clean
- functions suite **199/199** (193 + 6 new), via `dominant-color.unit.test.cjs` (solid / split / ordering / maxColors / transparency / hex-format) using sharp-built PNG fixtures.

## Remaining for full #105 (follow-up)
- An endpoint (e.g. `POST /api/capture/.../colors` or a rapid-add hook) that runs extraction and returns dominant hexes + catalog matches.
- Web + mobile UI to pick from extracted colors.

Kept as **Refs #105** (not Closes) since the user-facing matching/UI is still to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)