### PR TITLE
chore(functions): bundle swatchwatch-shared into deploy artifact (#95)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,8 +288,8 @@ jobs:
       - name: Build shared package
         run: npm run build --workspace=packages/shared
 
-      - name: Build functions
-        run: npm run build --workspace=packages/functions
+      - name: Bundle functions (inlines swatchwatch-shared)
+        run: npm run build:deploy --workspace=packages/functions
 
       - name: Prepare functions deployment package
         run: |
@@ -297,33 +297,27 @@ jobs:
           rm -rf "$DEPLOY_DIR"
           mkdir -p "$DEPLOY_DIR"
 
-          # Copy function app artifacts
+          # Function app artifacts: host.json + the single bundled entry.
+          # swatchwatch-shared is bundled into the entry, so the deploy package
+          # has no workspace dependency to materialize — eliminating the tarball
+          # pack, package.json rewrite, and symlink guardrail this step used to need.
           cp packages/functions/host.json "$DEPLOY_DIR/"
-          cp packages/functions/package.json "$DEPLOY_DIR/"
-          cp -r packages/functions/dist "$DEPLOY_DIR/"
+          cp packages/functions/dist-bundle/index.js "$DEPLOY_DIR/index.js"
 
-          # Pack the built shared package into a tarball and install from it.
-          # Avoid file:directory deps here because npm installs those as symlinks,
-          # which can fail to resolve reliably under WEBSITE_RUN_FROM_PACKAGE.
-          SHARED_TARBALL="$(npm pack --silent --workspace=packages/shared --pack-destination "$DEPLOY_DIR" | tail -n 1)"
-
-          # Rewrite the workspace reference to the local tarball
+          # Minimal package.json: entry point + external runtime deps only
+          # (everything not bundled). Generated from the source package.json with
+          # the workspace dependency dropped.
           node -e "
-            const pkg = JSON.parse(require('fs').readFileSync('$DEPLOY_DIR/package.json', 'utf8'));
-            pkg.dependencies['swatchwatch-shared'] = 'file:${SHARED_TARBALL}';
-            require('fs').writeFileSync('$DEPLOY_DIR/package.json', JSON.stringify(pkg, null, 2));
+            const src = JSON.parse(require('fs').readFileSync('packages/functions/package.json', 'utf8'));
+            const deps = { ...src.dependencies };
+            delete deps['swatchwatch-shared'];
+            const out = { name: src.name, version: src.version, main: 'index.js', dependencies: deps };
+            require('fs').writeFileSync('$DEPLOY_DIR/package.json', JSON.stringify(out, null, 2));
           "
 
-          # Install production-only deps into the self-contained deploy dir
+          # Install production (external) deps into the self-contained deploy dir.
           cd "$DEPLOY_DIR"
           npm install --omit=dev --ignore-scripts
-
-          # Guardrail: ensure the shared package is materialized (not symlinked)
-          if [ -L "node_modules/swatchwatch-shared" ]; then
-            echo "Expected node_modules/swatchwatch-shared to be a real directory, but it is a symlink."
-            ls -la "node_modules/swatchwatch-shared"
-            exit 1
-          fi
 
       - name: Azure login (OIDC)
         uses: azure/login@v3

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .next/
 out/
 dist/
+dist-bundle/
 build/
 
 # Azure Functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -18667,6 +18667,7 @@
         "@types/node": "^22.10.0",
         "@types/pg": "^8.16.0",
         "azure-functions-core-tools": "^4.6.0",
+        "esbuild": "^0.28.0",
         "node-pg-migrate": "^8.0.4",
         "typescript": "^5.3.0"
       }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "build:deploy": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist-bundle/index.js --external:@azure/functions --external:@azure/storage-queue --external:applicationinsights --external:jose --external:p-limit --external:pg --external:redis --external:sharp",
     "pretest": "npm run build --workspace=swatchwatch-shared && npm run build",
     "test": "node --test tests/*.unit.test.cjs",
     "pack": "func pack --output ./dist/functions.zip --skip-install",
@@ -29,6 +30,7 @@
     "@types/node": "^22.10.0",
     "@types/pg": "^8.16.0",
     "azure-functions-core-tools": "^4.6.0",
+    "esbuild": "^0.28.0",
     "node-pg-migrate": "^8.0.4",
     "typescript": "^5.3.0"
   }


### PR DESCRIPTION
## Summary (DRAFT — needs one real dev deploy to validate)
Closes #95. Replaces the deploy-time workspace-dependency dance — `npm pack` tarball + `package.json` rewrite + symlink guardrail, the root cause of the **5 prior deploy-packaging breakages** the issue documents — with an **esbuild bundle** that inlines `swatchwatch-shared`.

### Changes
- **`build:deploy`** (esbuild): bundles `src/index.ts` → `dist-bundle/index.js`, inlining the workspace package and keeping runtime deps external (`@azure/functions`, `pg`, `redis`, `sharp`, `jose`, `applicationinsights`, `@azure/storage-queue`, `p-limit`). The `tsc` build is untouched, so local dev and the unit tests (which load per-file `dist/lib/*.js`) keep working.
- **`deploy.yml`**: ship `host.json` + the single bundled `index.js` + a minimal generated `package.json` (workspace dep dropped) + `npm install --omit=dev`. The tarball/rewrite/guardrail steps are gone.
- gitignore `dist-bundle/`.

### Verification (local)
- Bundle builds (373 KB); **0** runtime `require("swatchwatch-shared")` — fully inlined.
- `node -e "require('./dist-bundle/index.js')"` loads and **executes every `app.http()` registration** (the host SDK logs all 37 functions in test mode) → entry point + externals + inlined shared all resolve.
- `npm run build:functions` clean; functions tests **193/193**; web lint clean.

### Why draft
The one thing I can't verify from here is the **live Azure zip-deploy** (`WEBSITE_RUN_FROM_PACKAGE`) actually loading the bundled artifact. Given this touches the production deploy path, please run one dev deploy to smoke-test before merging.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)